### PR TITLE
[#1] Add Taskfile and config template for automated setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 jira8
+*.exe
 .jira.yaml
 .env
+.claude/

--- a/.jira.yaml.example
+++ b/.jira.yaml.example
@@ -1,0 +1,16 @@
+# jira8 configuration file
+# Copy to ~/.jira.yaml and fill in your credentials
+#
+# Auth: Basic Auth (user + password) or Bearer token (token)
+
+url: https://jira.example.com/jira
+
+# Basic Auth (default for Jira Server without PAT)
+user: your.username
+password: your_password
+
+# Bearer token (uncomment if using Personal Access Token)
+# token: YOUR_PAT_HERE
+
+# Default project (optional — can also use --project flag)
+# project: YOUR_PROJECT_NAME

--- a/README.md
+++ b/README.md
@@ -2,10 +2,44 @@
 
 CLI tool for interacting with Jira Server 8 REST API v2, with MCP server support for AI agent integration.
 
-## Installation
+## Quick Setup
+
+Requires [Go](https://go.dev/) and [Task](https://taskfile.dev/).
+
+```bash
+task setup
+```
+
+This will:
+
+1. Build the binary
+2. Install it to `~/bin` (Windows) or `~/.local/bin` (Linux)
+3. Create `~/.jira.yaml` from the example template
+
+Then edit `~/.jira.yaml` with your credentials and verify:
+
+```bash
+task verify
+```
+
+### Available tasks
+
+| Task | Description |
+|------|-------------|
+| `task setup` | Full setup: build + install + create config |
+| `task build` | Build the binary |
+| `task install` | Build and copy to user PATH |
+| `task setup-config` | Copy config template to `~/.jira.yaml` |
+| `task verify` | Check binary and config are OK |
+| `task lint` | Run gofmt + go vet |
+| `task test` | Run all tests |
+| `task clean` | Remove built binary |
+
+### Manual installation
 
 ```bash
 go build -o jira8 .
+cp jira8 ~/bin/       # or ~/.local/bin/ on Linux
 ```
 
 ## Configuration

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,75 @@
+version: "3"
+
+vars:
+  BINARY: jira8{{if eq OS "windows"}}.exe{{end}}
+  INSTALL_DIR: '{{if eq OS "windows"}}{{.HOME}}/bin{{else}}{{.HOME}}/.local/bin{{end}}'
+
+tasks:
+  default:
+    desc: Show available tasks
+    cmds:
+      - task --list
+
+  build:
+    desc: Build the jira8 binary
+    cmds:
+      - go build -o {{.BINARY}} .
+    sources:
+      - "**/*.go"
+      - go.mod
+      - go.sum
+    generates:
+      - "{{.BINARY}}"
+
+  lint:
+    desc: Run linters
+    cmds:
+      - gofmt -s -w .
+      - go vet ./...
+
+  test:
+    desc: Run all tests
+    cmds:
+      - go test ./...
+
+  install:
+    desc: Build and install jira8 to user PATH
+    deps: [build]
+    cmds:
+      - mkdir -p {{.INSTALL_DIR}}
+      - cp {{.BINARY}} {{.INSTALL_DIR}}/{{.BINARY}}
+      - echo "Installed {{.BINARY}} to {{.INSTALL_DIR}}/{{.BINARY}}"
+    status:
+      - test -f {{.INSTALL_DIR}}/{{.BINARY}}
+      - test {{.INSTALL_DIR}}/{{.BINARY}} -nt {{.BINARY}}
+
+  setup-config:
+    desc: Copy example config to ~/.jira.yaml (will NOT overwrite existing)
+    cmds:
+      - cp -n .jira.yaml.example {{.HOME}}/.jira.yaml
+      - echo "Config created at ~/.jira.yaml — edit it with your credentials"
+    preconditions:
+      - sh: "! test -f {{.HOME}}/.jira.yaml"
+        msg: "~/.jira.yaml already exists. Edit it manually or remove it first."
+
+  setup:
+    desc: Full setup — build, install, and create config
+    cmds:
+      - task: install
+      - task: setup-config
+      - echo ""
+      - echo "Setup complete. Next steps:"
+      - echo "  1. Edit ~/.jira.yaml with your Jira credentials"
+      - echo "  2. Verify PATH includes {{.INSTALL_DIR}}"
+      - 'echo "  3. Test with: jira8 issue list --project YOUR_PROJECT"'
+
+  verify:
+    desc: Verify installation works (requires configured ~/.jira.yaml)
+    cmds:
+      - '{{.BINARY}} --help > /dev/null 2>&1 && echo "Binary OK" || echo "Binary not found in PATH"'
+      - 'test -f {{.HOME}}/.jira.yaml && echo "Config OK" || echo "Config missing: run task setup-config"'
+
+  clean:
+    desc: Remove built binary
+    cmds:
+      - rm -f {{.BINARY}}


### PR DESCRIPTION
## Summary

- Add `Taskfile.yml` with tasks for build, install, config setup, lint, test, and verification
- Add `.jira.yaml.example` as a credential-free config template
- Update `README.md` with Quick Setup section and available tasks table

Closes #1

## Test plan

- [ ] `task setup` on a clean Windows machine
- [ ] `task setup` on a clean Linux machine
- [ ] `task verify` confirms binary and config
- [ ] `task build` / `task lint` / `task test` work independently
- [ ] `.jira.yaml.example` contains no real credentials or domain-specific values