### PR TITLE
[#4] Add worklog support (add, list)

### DIFF
--- a/cmd/issue/issue.go
+++ b/cmd/issue/issue.go
@@ -16,4 +16,6 @@ func init() {
 	IssueCmd.AddCommand(editCmd)
 	IssueCmd.AddCommand(transitionCmd)
 	IssueCmd.AddCommand(transitionsCmd)
+	IssueCmd.AddCommand(worklogAddCmd)
+	IssueCmd.AddCommand(worklogListCmd)
 }

--- a/cmd/issue/worklog_add.go
+++ b/cmd/issue/worklog_add.go
@@ -1,0 +1,64 @@
+package issue
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/amplia/jira8/cmd/app"
+	"github.com/amplia/jira8/internal/models"
+	"github.com/spf13/cobra"
+)
+
+var worklogAddCmd = &cobra.Command{
+	Use:     "worklog-add ISSUE-KEY",
+	Aliases: []string{"wla"},
+	Short:   "Add a worklog entry to an issue",
+	Example: `  jira8 issue worklog-add ESA-123 --time 2h --comment "Sprint review"
+  jira8 issue worklog-add ESA-123 --time 30m --date "2026-04-07T09:00:00.000+0200"`,
+	Args: cobra.ExactArgs(1),
+	RunE: runWorklogAdd,
+}
+
+func init() {
+	worklogAddCmd.Flags().String("time", "", "Time spent (e.g., 2h, 30m, 1d) (required)")
+	worklogAddCmd.Flags().String("date", "", "Start date/time in ISO 8601 (optional, defaults to now)")
+	worklogAddCmd.Flags().String("comment", "", "Worklog comment (optional)")
+	_ = worklogAddCmd.MarkFlagRequired("time")
+}
+
+func runWorklogAdd(cmd *cobra.Command, args []string) error {
+	a := app.Get()
+	key := args[0]
+
+	timeSpent, _ := cmd.Flags().GetString("time")
+	started, _ := cmd.Flags().GetString("date")
+	comment, _ := cmd.Flags().GetString("comment")
+
+	req := &models.AddWorklogRequest{
+		TimeSpent: timeSpent,
+	}
+	if started != "" {
+		req.Started = started
+	}
+	if comment != "" {
+		req.Comment = comment
+	}
+
+	wl, err := a.Client.AddWorklog(context.Background(), key, req)
+	if err != nil {
+		return err
+	}
+
+	if a.Output == "json" {
+		data, err := json.MarshalIndent(wl, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(data))
+		return nil
+	}
+
+	fmt.Printf("Worklog added to %s: %s (ID: %s)\n", key, wl.TimeSpent, wl.ID)
+	return nil
+}

--- a/cmd/issue/worklog_list.go
+++ b/cmd/issue/worklog_list.go
@@ -1,0 +1,61 @@
+package issue
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/amplia/jira8/cmd/app"
+	"github.com/spf13/cobra"
+)
+
+var worklogListCmd = &cobra.Command{
+	Use:     "worklog-list ISSUE-KEY",
+	Aliases: []string{"wll"},
+	Short:   "List worklog entries for an issue",
+	Example: "  jira8 issue worklog-list ESA-123",
+	Args:    cobra.ExactArgs(1),
+	RunE:    runWorklogList,
+}
+
+func runWorklogList(cmd *cobra.Command, args []string) error {
+	a := app.Get()
+	key := args[0]
+
+	worklogs, err := a.Client.GetWorklogs(context.Background(), key)
+	if err != nil {
+		return err
+	}
+
+	if a.Output == "json" {
+		data, err := json.MarshalIndent(worklogs, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(data))
+		return nil
+	}
+
+	if len(worklogs) == 0 {
+		fmt.Printf("No worklogs found for %s\n", key)
+		return nil
+	}
+
+	fmt.Printf("Worklogs for %s (%d entries):\n\n", key, len(worklogs))
+	for _, wl := range worklogs {
+		author := "unknown"
+		if wl.Author != nil {
+			author = wl.Author.DisplayName
+		}
+		started := wl.Started
+		if len(started) > 10 {
+			started = started[:10]
+		}
+		fmt.Printf("  %s | %s | %s", author, started, wl.TimeSpent)
+		if wl.Comment != "" {
+			fmt.Printf(" | %s", wl.Comment)
+		}
+		fmt.Println()
+	}
+	return nil
+}

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -102,6 +102,25 @@ func runMCPServe(cmd *cobra.Command, args []string) error {
 		listTransitionsHandler(jc),
 	)
 
+	s.AddTool(
+		mcp.NewTool("jira_add_worklog",
+			mcp.WithDescription("Add a worklog entry to a Jira issue"),
+			mcp.WithString("key", mcp.Required(), mcp.Description("Issue key (e.g. ESA-123)")),
+			mcp.WithString("time_spent", mcp.Required(), mcp.Description("Time spent (e.g., 2h, 30m, 1d)")),
+			mcp.WithString("started", mcp.Description("Start date/time in ISO 8601 (optional, defaults to now)")),
+			mcp.WithString("comment", mcp.Description("Worklog comment")),
+		),
+		addWorklogHandler(jc),
+	)
+
+	s.AddTool(
+		mcp.NewTool("jira_list_worklogs",
+			mcp.WithDescription("List worklog entries for a Jira issue"),
+			mcp.WithString("key", mcp.Required(), mcp.Description("Issue key (e.g. ESA-123)")),
+		),
+		listWorklogsHandler(jc),
+	)
+
 	return server.ServeStdio(s)
 }
 
@@ -292,6 +311,48 @@ func transitionIssueHandler(jc *client.Client) server.ToolHandlerFunc {
 			target = match.To.Name
 		}
 		return mcp.NewToolResultText(fmt.Sprintf(`{"transitioned": "%s", "to": "%s"}`, key, target)), nil
+	}
+}
+
+func addWorklogHandler(jc *client.Client) server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		key, err := req.RequireString("key")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		timeSpent, err := req.RequireString("time_spent")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		wlReq := &models.AddWorklogRequest{
+			TimeSpent: timeSpent,
+			Started:   req.GetString("started", ""),
+			Comment:   req.GetString("comment", ""),
+		}
+
+		wl, err := jc.AddWorklog(ctx, key, wlReq)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		return mcp.NewToolResultText(toJSON(wl)), nil
+	}
+}
+
+func listWorklogsHandler(jc *client.Client) server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		key, err := req.RequireString("key")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		worklogs, err := jc.GetWorklogs(ctx, key)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		return mcp.NewToolResultText(toJSON(worklogs)), nil
 	}
 }
 

--- a/internal/client/jira.go
+++ b/internal/client/jira.go
@@ -234,6 +234,34 @@ func (c *Client) DoTransition(ctx context.Context, key string, req *models.Trans
 	return err
 }
 
+// AddWorklog adds a worklog entry to an issue.
+func (c *Client) AddWorklog(ctx context.Context, key string, req *models.AddWorklogRequest) (*models.Worklog, error) {
+	data, err := c.do(ctx, http.MethodPost, "/issue/"+url.PathEscape(key)+"/worklog", req)
+	if err != nil {
+		return nil, err
+	}
+
+	var wl models.Worklog
+	if err := json.Unmarshal(data, &wl); err != nil {
+		return nil, fmt.Errorf("parsing worklog response: %w", err)
+	}
+	return &wl, nil
+}
+
+// GetWorklogs returns all worklog entries for an issue.
+func (c *Client) GetWorklogs(ctx context.Context, key string) ([]models.Worklog, error) {
+	data, err := c.do(ctx, http.MethodGet, "/issue/"+url.PathEscape(key)+"/worklog", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp models.WorklogsResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return nil, fmt.Errorf("parsing worklogs: %w", err)
+	}
+	return resp.Worklogs, nil
+}
+
 // GetMyself returns the currently authenticated user.
 func (c *Client) GetMyself(ctx context.Context) (*models.User, error) {
 	data, err := c.do(ctx, http.MethodGet, "/myself", nil)

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -174,6 +174,35 @@ type CreateMetaProject struct {
 	IssueTypes []IssueType `json:"issuetypes"`
 }
 
+// AddWorklogRequest is the POST body for /rest/api/2/issue/{key}/worklog.
+type AddWorklogRequest struct {
+	TimeSpent string `json:"timeSpent"`
+	Started   string `json:"started,omitempty"`
+	Comment   string `json:"comment,omitempty"`
+}
+
+// Worklog represents a single worklog entry.
+type Worklog struct {
+	ID             string `json:"id"`
+	Self           string `json:"self"`
+	Author         *User  `json:"author,omitempty"`
+	UpdateAuthor   *User  `json:"updateAuthor,omitempty"`
+	Created        string `json:"created"`
+	Updated        string `json:"updated"`
+	Started        string `json:"started"`
+	TimeSpent      string `json:"timeSpent"`
+	TimeSpentSecs  int    `json:"timeSpentSeconds"`
+	Comment        string `json:"comment,omitempty"`
+}
+
+// WorklogsResponse is the response from GET /rest/api/2/issue/{key}/worklog.
+type WorklogsResponse struct {
+	StartAt    int       `json:"startAt"`
+	MaxResults int       `json:"maxResults"`
+	Total      int       `json:"total"`
+	Worklogs   []Worklog `json:"worklogs"`
+}
+
 // JiraError represents a Jira API error response.
 type JiraError struct {
 	ErrorMessages []string          `json:"errorMessages"`


### PR DESCRIPTION
## Summary
- Add `worklog-add` and `worklog-list` CLI subcommands for time tracking
- Add `jira_add_worklog` and `jira_list_worklogs` MCP tools
- Add `AddWorklog`/`GetWorklogs` client methods + model structs

## Details
- `jira8 issue worklog-add KEY --time 2h [--date ISO8601] [--comment "..."]`
- `jira8 issue worklog-list KEY`
- Both support `-o json` output
- Aliases: `wla` (add), `wll` (list)

## Test plan
- Verified `worklog-list ESA-108` returns existing worklogs (text + json)
- Verified `worklog-list ESA-110` returns worklogs added via REST API
- Build + vet clean

Closes #4