### PR TITLE
[#3] Include parent field in issue view and list output

### DIFF
--- a/cmd/issue/format.go
+++ b/cmd/issue/format.go
@@ -135,6 +135,14 @@ func printIssueDetail(issue *models.Issue) {
 	printField("Assignee", userName(f.Assignee))
 	printField("Reporter", userName(f.Reporter))
 
+	if f.Parent != nil {
+		parentStr := f.Parent.Key
+		if f.Parent.Fields != nil && f.Parent.Fields.Summary != "" {
+			parentStr += " — " + f.Parent.Fields.Summary
+		}
+		printField("Parent", parentStr)
+	}
+
 	if f.Project != nil {
 		printField("Project", fmt.Sprintf("%s (%s)", f.Project.Name, f.Project.Key))
 	}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -26,11 +26,25 @@ type IssueFields struct {
 	Assignee    *User       `json:"assignee,omitempty"`
 	Reporter    *User       `json:"reporter,omitempty"`
 	Project     *Project    `json:"project,omitempty"`
+	Parent      *ParentIssue `json:"parent,omitempty"`
 	Created     string      `json:"created,omitempty"`
 	Updated     string      `json:"updated,omitempty"`
 	Labels      []string    `json:"labels,omitempty"`
 	Components  []Component `json:"components,omitempty"`
 	Comment     *Comments   `json:"comment,omitempty"`
+}
+
+// ParentIssue represents the parent of a Sub-task issue.
+type ParentIssue struct {
+	ID     string       `json:"id"`
+	Key    string       `json:"key"`
+	Self   string       `json:"self,omitempty"`
+	Fields *ParentFields `json:"fields,omitempty"`
+}
+
+// ParentFields contains the summary of a parent issue (returned by Jira inside parent.fields).
+type ParentFields struct {
+	Summary string `json:"summary"`
 }
 
 // Status represents a Jira issue status.


### PR DESCRIPTION
## Summary

- Add `Parent` field to `IssueFields` model (maps Jira's `parent` object with key, id, and summary)
- Show `Parent: ESA-65 — Summary text` line in `issue view` text output for Sub-task issues
- Include `parent` object in JSON output for both `issue view` and `issue list`

Closes #3

## Test plan

- [ ] `jira8 issue view KEY` on a Sub-task shows `Parent:` line
- [ ] `jira8 issue view KEY -o json` includes `parent` object with key and summary
- [ ] `jira8 issue view KEY` on a non-Sub-task does NOT show `Parent:` line
- [ ] `jira8 issue list -o json` includes `parent` for Sub-task entries