### PR TITLE
[#6] Support creating sub-tasks with --parent flag

### DIFF
--- a/cmd/issue/create.go
+++ b/cmd/issue/create.go
@@ -25,6 +25,7 @@ func init() {
 	createCmd.Flags().String("description", "", "Issue description")
 	createCmd.Flags().String("assignee", "", "Assignee username (use 'me' for current user)")
 	createCmd.Flags().String("priority", "", "Issue priority")
+	createCmd.Flags().String("parent", "", "Parent issue key for Sub-task creation (e.g. ESA-65)")
 
 	_ = createCmd.MarkFlagRequired("summary")
 }
@@ -41,6 +42,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	description, _ := cmd.Flags().GetString("description")
 	assignee, _ := cmd.Flags().GetString("assignee")
 	priority, _ := cmd.Flags().GetString("priority")
+	parent, _ := cmd.Flags().GetString("parent")
 
 	req := &models.CreateIssueRequest{
 		Fields: models.CreateIssueFields{
@@ -65,6 +67,10 @@ func runCreate(cmd *cobra.Command, args []string) error {
 
 	if priority != "" {
 		req.Fields.Priority = &models.PriorityRef{Name: priority}
+	}
+
+	if parent != "" {
+		req.Fields.Parent = &models.IssueKeyRef{Key: parent}
 	}
 
 	resp, err := a.Client.CreateIssue(context.Background(), req)

--- a/cmd/issue/format.go
+++ b/cmd/issue/format.go
@@ -135,6 +135,14 @@ func printIssueDetail(issue *models.Issue) {
 	printField("Assignee", userName(f.Assignee))
 	printField("Reporter", userName(f.Reporter))
 
+	if f.Parent != nil {
+		parentStr := f.Parent.Key
+		if f.Parent.Fields != nil && f.Parent.Fields.Summary != "" {
+			parentStr += " — " + f.Parent.Fields.Summary
+		}
+		printField("Parent", parentStr)
+	}
+
 	if f.Project != nil {
 		printField("Project", fmt.Sprintf("%s (%s)", f.Project.Name, f.Project.Key))
 	}

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -69,6 +69,7 @@ func runMCPServe(cmd *cobra.Command, args []string) error {
 			mcp.WithString("description", mcp.Description("Issue description")),
 			mcp.WithString("assignee", mcp.Description("Assignee username")),
 			mcp.WithString("priority", mcp.Description("Priority name")),
+			mcp.WithString("parent", mcp.Description("Parent issue key for Sub-task creation (e.g. ESA-65)")),
 		),
 		createIssueHandler(jc),
 	)
@@ -206,6 +207,10 @@ func createIssueHandler(jc *client.Client) server.ToolHandlerFunc {
 
 		if priority := req.GetString("priority", ""); priority != "" {
 			createReq.Fields.Priority = &models.PriorityRef{Name: priority}
+		}
+
+		if parent := req.GetString("parent", ""); parent != "" {
+			createReq.Fields.Parent = &models.IssueKeyRef{Key: parent}
 		}
 
 		resp, err := jc.CreateIssue(ctx, createReq)

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -123,6 +123,12 @@ type CreateIssueFields struct {
 	Description string       `json:"description,omitempty"`
 	Assignee    *UserRef     `json:"assignee,omitempty"`
 	Priority    *PriorityRef `json:"priority,omitempty"`
+	Parent      *IssueKeyRef `json:"parent,omitempty"`
+}
+
+// IssueKeyRef references an issue by key (used for parent in sub-task creation).
+type IssueKeyRef struct {
+	Key string `json:"key"`
 }
 
 // ProjectRef references a project by key.

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -26,11 +26,25 @@ type IssueFields struct {
 	Assignee    *User       `json:"assignee,omitempty"`
 	Reporter    *User       `json:"reporter,omitempty"`
 	Project     *Project    `json:"project,omitempty"`
+	Parent      *ParentIssue `json:"parent,omitempty"`
 	Created     string      `json:"created,omitempty"`
 	Updated     string      `json:"updated,omitempty"`
 	Labels      []string    `json:"labels,omitempty"`
 	Components  []Component `json:"components,omitempty"`
 	Comment     *Comments   `json:"comment,omitempty"`
+}
+
+// ParentIssue represents the parent of a Sub-task issue.
+type ParentIssue struct {
+	ID     string       `json:"id"`
+	Key    string       `json:"key"`
+	Self   string       `json:"self,omitempty"`
+	Fields *ParentFields `json:"fields,omitempty"`
+}
+
+// ParentFields contains the summary of a parent issue (returned by Jira inside parent.fields).
+type ParentFields struct {
+	Summary string `json:"summary"`
 }
 
 // Status represents a Jira issue status.


### PR DESCRIPTION
## Summary

- Add `--parent KEY` flag to `issue create` CLI command
- Add `parent` parameter to `jira_create_issue` MCP tool
- Add `IssueKeyRef` and `Parent` field to `CreateIssueFields` model
- Sends `"parent": {"key": "KEY"}` in create request when provided

Depends on #7 (merge that first)
Closes #6

## Usage

```bash
jira8 issue create --type "Sub-task" --parent ESA-65 --summary "Implement retry logic"
```

## Test plan

- [ ] `jira8 issue create --type "Sub-task" --parent ESA-65 --summary "Test"` creates a Sub-task under ESA-65
- [ ] `jira8 issue create --summary "Normal task"` still works without `--parent`
- [ ] MCP tool `jira_create_issue` with `parent` parameter creates Sub-task correctly