### PR TITLE
[#11] Add comment-edit support (CLI + MCP)

### DIFF
--- a/cmd/issue/comment_edit.go
+++ b/cmd/issue/comment_edit.go
@@ -1,0 +1,51 @@
+package issue
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/amplia/jira8/cmd/app"
+	"github.com/spf13/cobra"
+)
+
+var commentEditCmd = &cobra.Command{
+	Use:     "comment-edit ISSUE-KEY",
+	Aliases: []string{"ce"},
+	Short:   "Edit a comment on an issue",
+	Example: `  jira8 issue comment-edit ESA-123 --id 84887 --body "Updated text"`,
+	Args:    cobra.ExactArgs(1),
+	RunE:    runCommentEdit,
+}
+
+func init() {
+	commentEditCmd.Flags().String("id", "", "Comment ID (required)")
+	commentEditCmd.Flags().String("body", "", "Updated comment body (required)")
+	_ = commentEditCmd.MarkFlagRequired("id")
+	_ = commentEditCmd.MarkFlagRequired("body")
+}
+
+func runCommentEdit(cmd *cobra.Command, args []string) error {
+	a := app.Get()
+	key := args[0]
+
+	commentID, _ := cmd.Flags().GetString("id")
+	body, _ := cmd.Flags().GetString("body")
+
+	comment, err := a.Client.EditComment(context.Background(), key, commentID, body)
+	if err != nil {
+		return err
+	}
+
+	if a.Output == "json" {
+		data, err := json.MarshalIndent(comment, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(data))
+		return nil
+	}
+
+	fmt.Printf("Comment %s updated on %s\n", comment.ID, key)
+	return nil
+}

--- a/cmd/issue/comment_list.go
+++ b/cmd/issue/comment_list.go
@@ -48,7 +48,7 @@ func runCommentList(cmd *cobra.Command, args []string) error {
 		if len(created) > 10 {
 			created = created[:10]
 		}
-		fmt.Printf("\n  %s  %s\n", headerStyle.Render(userName(c.Author)), labelStyle.Render(created))
+		fmt.Printf("\n  %s  %s  %s\n", labelStyle.Render("#"+c.ID), headerStyle.Render(userName(c.Author)), labelStyle.Render(created))
 		for _, line := range strings.Split(c.Body, "\n") {
 			fmt.Printf("  %s\n", line)
 		}

--- a/cmd/issue/issue.go
+++ b/cmd/issue/issue.go
@@ -20,4 +20,5 @@ func init() {
 	IssueCmd.AddCommand(worklogListCmd)
 	IssueCmd.AddCommand(commentAddCmd)
 	IssueCmd.AddCommand(commentListCmd)
+	IssueCmd.AddCommand(commentEditCmd)
 }

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -140,6 +140,16 @@ func runMCPServe(cmd *cobra.Command, args []string) error {
 	)
 
 	s.AddTool(
+		mcp.NewTool("jira_edit_comment",
+			mcp.WithDescription("Edit an existing comment on a Jira issue"),
+			mcp.WithString("key", mcp.Required(), mcp.Description("Issue key (e.g. ESA-123)")),
+			mcp.WithString("comment_id", mcp.Required(), mcp.Description("Comment ID")),
+			mcp.WithString("body", mcp.Required(), mcp.Description("Updated comment body (wiki markup)")),
+		),
+		editCommentHandler(jc),
+	)
+
+	s.AddTool(
 		mcp.NewTool("jira_list_issue_types",
 			mcp.WithDescription("List issue types available for creation in a project (e.g. Bug, Task, Story, Sub-task)"),
 			mcp.WithString("project", mcp.Required(), mcp.Description("Project key (e.g. ESA)")),
@@ -434,6 +444,30 @@ func listCommentsHandler(jc *client.Client) server.ToolHandlerFunc {
 		}
 
 		return mcp.NewToolResultText(toJSON(comments)), nil
+	}
+}
+
+func editCommentHandler(jc *client.Client) server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		key, err := req.RequireString("key")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		commentID, err := req.RequireString("comment_id")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		body, err := req.RequireString("body")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		comment, err := jc.EditComment(ctx, key, commentID, body)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		return mcp.NewToolResultText(toJSON(comment)), nil
 	}
 }
 

--- a/internal/client/jira.go
+++ b/internal/client/jira.go
@@ -276,6 +276,21 @@ func (c *Client) AddComment(ctx context.Context, key string, req *models.AddComm
 	return &comment, nil
 }
 
+// EditComment updates an existing comment on an issue.
+func (c *Client) EditComment(ctx context.Context, key, commentID, body string) (*models.Comment, error) {
+	path := "/issue/" + url.PathEscape(key) + "/comment/" + url.PathEscape(commentID)
+	data, err := c.do(ctx, http.MethodPut, path, &models.AddCommentRequest{Body: body})
+	if err != nil {
+		return nil, err
+	}
+
+	var comment models.Comment
+	if err := json.Unmarshal(data, &comment); err != nil {
+		return nil, fmt.Errorf("parsing comment response: %w", err)
+	}
+	return &comment, nil
+}
+
 // GetComments returns all comments for an issue.
 func (c *Client) GetComments(ctx context.Context, key string) ([]models.Comment, error) {
 	data, err := c.do(ctx, http.MethodGet, "/issue/"+url.PathEscape(key)+"/comment", nil)

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -18,27 +18,27 @@ type Issue struct {
 
 // IssueFields contains the fields of a Jira issue.
 type IssueFields struct {
-	Summary     string      `json:"summary"`
-	Description string      `json:"description,omitempty"`
-	Status      *Status     `json:"status,omitempty"`
-	IssueType   *IssueType  `json:"issuetype,omitempty"`
-	Priority    *Priority   `json:"priority,omitempty"`
-	Assignee    *User       `json:"assignee,omitempty"`
-	Reporter    *User       `json:"reporter,omitempty"`
-	Project     *Project    `json:"project,omitempty"`
+	Summary     string       `json:"summary"`
+	Description string       `json:"description,omitempty"`
+	Status      *Status      `json:"status,omitempty"`
+	IssueType   *IssueType   `json:"issuetype,omitempty"`
+	Priority    *Priority    `json:"priority,omitempty"`
+	Assignee    *User        `json:"assignee,omitempty"`
+	Reporter    *User        `json:"reporter,omitempty"`
+	Project     *Project     `json:"project,omitempty"`
 	Parent      *ParentIssue `json:"parent,omitempty"`
-	Created     string      `json:"created,omitempty"`
-	Updated     string      `json:"updated,omitempty"`
-	Labels      []string    `json:"labels,omitempty"`
-	Components  []Component `json:"components,omitempty"`
-	Comment     *Comments   `json:"comment,omitempty"`
+	Created     string       `json:"created,omitempty"`
+	Updated     string       `json:"updated,omitempty"`
+	Labels      []string     `json:"labels,omitempty"`
+	Components  []Component  `json:"components,omitempty"`
+	Comment     *Comments    `json:"comment,omitempty"`
 }
 
 // ParentIssue represents the parent of a Sub-task issue.
 type ParentIssue struct {
-	ID     string       `json:"id"`
-	Key    string       `json:"key"`
-	Self   string       `json:"self,omitempty"`
+	ID     string        `json:"id"`
+	Key    string        `json:"key"`
+	Self   string        `json:"self,omitempty"`
 	Fields *ParentFields `json:"fields,omitempty"`
 }
 
@@ -93,9 +93,11 @@ type Comments struct {
 
 // Comment represents a single comment.
 type Comment struct {
+	ID      string `json:"id"`
 	Author  *User  `json:"author"`
 	Body    string `json:"body"`
 	Created string `json:"created"`
+	Updated string `json:"updated,omitempty"`
 }
 
 // AddCommentRequest is the POST body for /rest/api/2/issue/{key}/comment.
@@ -216,16 +218,16 @@ type AddWorklogRequest struct {
 
 // Worklog represents a single worklog entry.
 type Worklog struct {
-	ID             string `json:"id"`
-	Self           string `json:"self"`
-	Author         *User  `json:"author,omitempty"`
-	UpdateAuthor   *User  `json:"updateAuthor,omitempty"`
-	Created        string `json:"created"`
-	Updated        string `json:"updated"`
-	Started        string `json:"started"`
-	TimeSpent      string `json:"timeSpent"`
-	TimeSpentSecs  int    `json:"timeSpentSeconds"`
-	Comment        string `json:"comment,omitempty"`
+	ID            string `json:"id"`
+	Self          string `json:"self"`
+	Author        *User  `json:"author,omitempty"`
+	UpdateAuthor  *User  `json:"updateAuthor,omitempty"`
+	Created       string `json:"created"`
+	Updated       string `json:"updated"`
+	Started       string `json:"started"`
+	TimeSpent     string `json:"timeSpent"`
+	TimeSpentSecs int    `json:"timeSpentSeconds"`
+	Comment       string `json:"comment,omitempty"`
 }
 
 // WorklogsResponse is the response from GET /rest/api/2/issue/{key}/worklog.


### PR DESCRIPTION
## Summary

- Add `comment-edit` CLI command (alias: `ce`) with `--id` and `--body` flags
- Add `jira_edit_comment` MCP tool for AI agent integration
- Add `EditComment` client method (`PUT /issue/{key}/comment/{id}`)
- Add `ID` and `Updated` fields to `Comment` model
- Show comment IDs in `comment-list` output for discoverability

## Test plan

- [ ] `jira8 issue comment-list ESA-123` — verify IDs are shown
- [ ] `jira8 issue comment-edit ESA-123 --id <ID> --body "updated"` — verify edit works
- [ ] `jira8 issue comment-edit ESA-123 --id <ID> --body "updated" -o json` — verify JSON output
- [ ] MCP: call `jira_edit_comment` with key, comment_id, body — verify response

Closes #11