### PR TITLE
[#12] Add comment-delete support (CLI + MCP)

### DIFF
--- a/cmd/issue/comment_delete.go
+++ b/cmd/issue/comment_delete.go
@@ -1,0 +1,54 @@
+package issue
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/amplia/jira8/cmd/app"
+	"github.com/spf13/cobra"
+)
+
+var commentDeleteCmd = &cobra.Command{
+	Use:     "comment-delete ISSUE-KEY",
+	Aliases: []string{"cd"},
+	Short:   "Delete a comment from an issue",
+	Example: `  jira8 issue comment-delete ESA-123 --id 84887
+  jira8 issue comment-delete ESA-123 --id 84887 --yes`,
+	Args: cobra.ExactArgs(1),
+	RunE: runCommentDelete,
+}
+
+func init() {
+	commentDeleteCmd.Flags().String("id", "", "Comment ID (required)")
+	commentDeleteCmd.Flags().Bool("yes", false, "Skip confirmation prompt")
+	_ = commentDeleteCmd.MarkFlagRequired("id")
+}
+
+func runCommentDelete(cmd *cobra.Command, args []string) error {
+	a := app.Get()
+	key := args[0]
+
+	commentID, _ := cmd.Flags().GetString("id")
+	yes, _ := cmd.Flags().GetBool("yes")
+
+	if !yes {
+		fmt.Printf("Delete comment %s from %s? [y/N] ", commentID, key)
+		reader := bufio.NewReader(os.Stdin)
+		answer, _ := reader.ReadString('\n')
+		answer = strings.TrimSpace(strings.ToLower(answer))
+		if answer != "y" && answer != "yes" {
+			fmt.Println("Cancelled.")
+			return nil
+		}
+	}
+
+	if err := a.Client.DeleteComment(context.Background(), key, commentID); err != nil {
+		return err
+	}
+
+	fmt.Printf("Comment %s deleted from %s\n", commentID, key)
+	return nil
+}

--- a/cmd/issue/comment_edit.go
+++ b/cmd/issue/comment_edit.go
@@ -1,0 +1,51 @@
+package issue
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/amplia/jira8/cmd/app"
+	"github.com/spf13/cobra"
+)
+
+var commentEditCmd = &cobra.Command{
+	Use:     "comment-edit ISSUE-KEY",
+	Aliases: []string{"ce"},
+	Short:   "Edit a comment on an issue",
+	Example: `  jira8 issue comment-edit ESA-123 --id 84887 --body "Updated text"`,
+	Args:    cobra.ExactArgs(1),
+	RunE:    runCommentEdit,
+}
+
+func init() {
+	commentEditCmd.Flags().String("id", "", "Comment ID (required)")
+	commentEditCmd.Flags().String("body", "", "Updated comment body (required)")
+	_ = commentEditCmd.MarkFlagRequired("id")
+	_ = commentEditCmd.MarkFlagRequired("body")
+}
+
+func runCommentEdit(cmd *cobra.Command, args []string) error {
+	a := app.Get()
+	key := args[0]
+
+	commentID, _ := cmd.Flags().GetString("id")
+	body, _ := cmd.Flags().GetString("body")
+
+	comment, err := a.Client.EditComment(context.Background(), key, commentID, body)
+	if err != nil {
+		return err
+	}
+
+	if a.Output == "json" {
+		data, err := json.MarshalIndent(comment, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(data))
+		return nil
+	}
+
+	fmt.Printf("Comment %s updated on %s\n", comment.ID, key)
+	return nil
+}

--- a/cmd/issue/comment_list.go
+++ b/cmd/issue/comment_list.go
@@ -48,7 +48,7 @@ func runCommentList(cmd *cobra.Command, args []string) error {
 		if len(created) > 10 {
 			created = created[:10]
 		}
-		fmt.Printf("\n  %s  %s\n", headerStyle.Render(userName(c.Author)), labelStyle.Render(created))
+		fmt.Printf("\n  %s  %s  %s\n", labelStyle.Render("#"+c.ID), headerStyle.Render(userName(c.Author)), labelStyle.Render(created))
 		for _, line := range strings.Split(c.Body, "\n") {
 			fmt.Printf("  %s\n", line)
 		}

--- a/cmd/issue/issue.go
+++ b/cmd/issue/issue.go
@@ -20,4 +20,5 @@ func init() {
 	IssueCmd.AddCommand(worklogListCmd)
 	IssueCmd.AddCommand(commentAddCmd)
 	IssueCmd.AddCommand(commentListCmd)
+	IssueCmd.AddCommand(commentEditCmd)
 }

--- a/cmd/issue/issue.go
+++ b/cmd/issue/issue.go
@@ -21,4 +21,5 @@ func init() {
 	IssueCmd.AddCommand(commentAddCmd)
 	IssueCmd.AddCommand(commentListCmd)
 	IssueCmd.AddCommand(commentEditCmd)
+	IssueCmd.AddCommand(commentDeleteCmd)
 }

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -150,6 +150,15 @@ func runMCPServe(cmd *cobra.Command, args []string) error {
 	)
 
 	s.AddTool(
+		mcp.NewTool("jira_delete_comment",
+			mcp.WithDescription("Delete a comment from a Jira issue"),
+			mcp.WithString("key", mcp.Required(), mcp.Description("Issue key (e.g. ESA-123)")),
+			mcp.WithString("comment_id", mcp.Required(), mcp.Description("Comment ID")),
+		),
+		deleteCommentHandler(jc),
+	)
+
+	s.AddTool(
 		mcp.NewTool("jira_list_issue_types",
 			mcp.WithDescription("List issue types available for creation in a project (e.g. Bug, Task, Story, Sub-task)"),
 			mcp.WithString("project", mcp.Required(), mcp.Description("Project key (e.g. ESA)")),
@@ -468,6 +477,25 @@ func editCommentHandler(jc *client.Client) server.ToolHandlerFunc {
 		}
 
 		return mcp.NewToolResultText(toJSON(comment)), nil
+	}
+}
+
+func deleteCommentHandler(jc *client.Client) server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		key, err := req.RequireString("key")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		commentID, err := req.RequireString("comment_id")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		if err := jc.DeleteComment(ctx, key, commentID); err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		return mcp.NewToolResultText(fmt.Sprintf(`{"deleted": "%s", "issue": "%s"}`, commentID, key)), nil
 	}
 }
 

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -140,6 +140,16 @@ func runMCPServe(cmd *cobra.Command, args []string) error {
 	)
 
 	s.AddTool(
+		mcp.NewTool("jira_edit_comment",
+			mcp.WithDescription("Edit an existing comment on a Jira issue"),
+			mcp.WithString("key", mcp.Required(), mcp.Description("Issue key (e.g. ESA-123)")),
+			mcp.WithString("comment_id", mcp.Required(), mcp.Description("Comment ID")),
+			mcp.WithString("body", mcp.Required(), mcp.Description("Updated comment body (wiki markup)")),
+		),
+		editCommentHandler(jc),
+	)
+
+	s.AddTool(
 		mcp.NewTool("jira_list_issue_types",
 			mcp.WithDescription("List issue types available for creation in a project (e.g. Bug, Task, Story, Sub-task)"),
 			mcp.WithString("project", mcp.Required(), mcp.Description("Project key (e.g. ESA)")),
@@ -434,6 +444,30 @@ func listCommentsHandler(jc *client.Client) server.ToolHandlerFunc {
 		}
 
 		return mcp.NewToolResultText(toJSON(comments)), nil
+	}
+}
+
+func editCommentHandler(jc *client.Client) server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		key, err := req.RequireString("key")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		commentID, err := req.RequireString("comment_id")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		body, err := req.RequireString("body")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		comment, err := jc.EditComment(ctx, key, commentID, body)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		return mcp.NewToolResultText(toJSON(comment)), nil
 	}
 }
 

--- a/internal/client/jira.go
+++ b/internal/client/jira.go
@@ -291,6 +291,13 @@ func (c *Client) EditComment(ctx context.Context, key, commentID, body string) (
 	return &comment, nil
 }
 
+// DeleteComment removes a comment from an issue.
+func (c *Client) DeleteComment(ctx context.Context, key, commentID string) error {
+	path := "/issue/" + url.PathEscape(key) + "/comment/" + url.PathEscape(commentID)
+	_, err := c.do(ctx, http.MethodDelete, path, nil)
+	return err
+}
+
 // GetComments returns all comments for an issue.
 func (c *Client) GetComments(ctx context.Context, key string) ([]models.Comment, error) {
 	data, err := c.do(ctx, http.MethodGet, "/issue/"+url.PathEscape(key)+"/comment", nil)

--- a/internal/client/jira.go
+++ b/internal/client/jira.go
@@ -276,6 +276,21 @@ func (c *Client) AddComment(ctx context.Context, key string, req *models.AddComm
 	return &comment, nil
 }
 
+// EditComment updates an existing comment on an issue.
+func (c *Client) EditComment(ctx context.Context, key, commentID, body string) (*models.Comment, error) {
+	path := "/issue/" + url.PathEscape(key) + "/comment/" + url.PathEscape(commentID)
+	data, err := c.do(ctx, http.MethodPut, path, &models.AddCommentRequest{Body: body})
+	if err != nil {
+		return nil, err
+	}
+
+	var comment models.Comment
+	if err := json.Unmarshal(data, &comment); err != nil {
+		return nil, fmt.Errorf("parsing comment response: %w", err)
+	}
+	return &comment, nil
+}
+
 // GetComments returns all comments for an issue.
 func (c *Client) GetComments(ctx context.Context, key string) ([]models.Comment, error) {
 	data, err := c.do(ctx, http.MethodGet, "/issue/"+url.PathEscape(key)+"/comment", nil)

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -18,27 +18,27 @@ type Issue struct {
 
 // IssueFields contains the fields of a Jira issue.
 type IssueFields struct {
-	Summary     string      `json:"summary"`
-	Description string      `json:"description,omitempty"`
-	Status      *Status     `json:"status,omitempty"`
-	IssueType   *IssueType  `json:"issuetype,omitempty"`
-	Priority    *Priority   `json:"priority,omitempty"`
-	Assignee    *User       `json:"assignee,omitempty"`
-	Reporter    *User       `json:"reporter,omitempty"`
-	Project     *Project    `json:"project,omitempty"`
+	Summary     string       `json:"summary"`
+	Description string       `json:"description,omitempty"`
+	Status      *Status      `json:"status,omitempty"`
+	IssueType   *IssueType   `json:"issuetype,omitempty"`
+	Priority    *Priority    `json:"priority,omitempty"`
+	Assignee    *User        `json:"assignee,omitempty"`
+	Reporter    *User        `json:"reporter,omitempty"`
+	Project     *Project     `json:"project,omitempty"`
 	Parent      *ParentIssue `json:"parent,omitempty"`
-	Created     string      `json:"created,omitempty"`
-	Updated     string      `json:"updated,omitempty"`
-	Labels      []string    `json:"labels,omitempty"`
-	Components  []Component `json:"components,omitempty"`
-	Comment     *Comments   `json:"comment,omitempty"`
+	Created     string       `json:"created,omitempty"`
+	Updated     string       `json:"updated,omitempty"`
+	Labels      []string     `json:"labels,omitempty"`
+	Components  []Component  `json:"components,omitempty"`
+	Comment     *Comments    `json:"comment,omitempty"`
 }
 
 // ParentIssue represents the parent of a Sub-task issue.
 type ParentIssue struct {
-	ID     string       `json:"id"`
-	Key    string       `json:"key"`
-	Self   string       `json:"self,omitempty"`
+	ID     string        `json:"id"`
+	Key    string        `json:"key"`
+	Self   string        `json:"self,omitempty"`
 	Fields *ParentFields `json:"fields,omitempty"`
 }
 
@@ -93,9 +93,11 @@ type Comments struct {
 
 // Comment represents a single comment.
 type Comment struct {
+	ID      string `json:"id"`
 	Author  *User  `json:"author"`
 	Body    string `json:"body"`
 	Created string `json:"created"`
+	Updated string `json:"updated,omitempty"`
 }
 
 // AddCommentRequest is the POST body for /rest/api/2/issue/{key}/comment.
@@ -216,16 +218,16 @@ type AddWorklogRequest struct {
 
 // Worklog represents a single worklog entry.
 type Worklog struct {
-	ID             string `json:"id"`
-	Self           string `json:"self"`
-	Author         *User  `json:"author,omitempty"`
-	UpdateAuthor   *User  `json:"updateAuthor,omitempty"`
-	Created        string `json:"created"`
-	Updated        string `json:"updated"`
-	Started        string `json:"started"`
-	TimeSpent      string `json:"timeSpent"`
-	TimeSpentSecs  int    `json:"timeSpentSeconds"`
-	Comment        string `json:"comment,omitempty"`
+	ID            string `json:"id"`
+	Self          string `json:"self"`
+	Author        *User  `json:"author,omitempty"`
+	UpdateAuthor  *User  `json:"updateAuthor,omitempty"`
+	Created       string `json:"created"`
+	Updated       string `json:"updated"`
+	Started       string `json:"started"`
+	TimeSpent     string `json:"timeSpent"`
+	TimeSpentSecs int    `json:"timeSpentSeconds"`
+	Comment       string `json:"comment,omitempty"`
 }
 
 // WorklogsResponse is the response from GET /rest/api/2/issue/{key}/worklog.


### PR DESCRIPTION
## Summary

- Add `comment-delete` CLI command (alias: `cd`) with `--id` and `--yes` flags
- Interactive confirmation prompt before deletion (skip with `--yes`)
- Add `jira_delete_comment` MCP tool for AI agent integration
- Add `DeleteComment` client method (`DELETE /issue/{key}/comment/{id}`)

## Test plan

- [ ] `jira8 issue comment-delete ESA-123 --id <ID>` — verify confirmation prompt, answer N → cancelled
- [ ] `jira8 issue comment-delete ESA-123 --id <ID>` — confirm with y → deleted
- [ ] `jira8 issue comment-delete ESA-123 --id <ID> --yes` — skip confirmation
- [ ] MCP: call `jira_delete_comment` with key, comment_id — verify response

> **Depends on #13** — merge comment-edit PR first to avoid conflicts.

Closes #12