### PR TITLE
[#16] Add worklog-delete support (CLI + MCP)

### DIFF
--- a/cmd/issue/issue.go
+++ b/cmd/issue/issue.go
@@ -18,6 +18,7 @@ func init() {
 	IssueCmd.AddCommand(transitionsCmd)
 	IssueCmd.AddCommand(worklogAddCmd)
 	IssueCmd.AddCommand(worklogListCmd)
+	IssueCmd.AddCommand(worklogDeleteCmd)
 	IssueCmd.AddCommand(commentAddCmd)
 	IssueCmd.AddCommand(commentListCmd)
 }

--- a/cmd/issue/worklog_delete.go
+++ b/cmd/issue/worklog_delete.go
@@ -1,0 +1,54 @@
+package issue
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/amplia/jira8/cmd/app"
+	"github.com/spf13/cobra"
+)
+
+var worklogDeleteCmd = &cobra.Command{
+	Use:     "worklog-delete ISSUE-KEY",
+	Aliases: []string{"wld"},
+	Short:   "Delete a worklog entry from an issue",
+	Example: `  jira8 issue worklog-delete ESA-123 --id 27705
+  jira8 issue worklog-delete ESA-123 --id 27705 --yes`,
+	Args: cobra.ExactArgs(1),
+	RunE: runWorklogDelete,
+}
+
+func init() {
+	worklogDeleteCmd.Flags().String("id", "", "Worklog ID (required)")
+	worklogDeleteCmd.Flags().Bool("yes", false, "Skip confirmation prompt")
+	_ = worklogDeleteCmd.MarkFlagRequired("id")
+}
+
+func runWorklogDelete(cmd *cobra.Command, args []string) error {
+	a := app.Get()
+	key := args[0]
+
+	worklogID, _ := cmd.Flags().GetString("id")
+	yes, _ := cmd.Flags().GetBool("yes")
+
+	if !yes {
+		fmt.Printf("Delete worklog %s from %s? [y/N] ", worklogID, key)
+		reader := bufio.NewReader(os.Stdin)
+		answer, _ := reader.ReadString('\n')
+		answer = strings.TrimSpace(strings.ToLower(answer))
+		if answer != "y" && answer != "yes" {
+			fmt.Println("Cancelled.")
+			return nil
+		}
+	}
+
+	if err := a.Client.DeleteWorklog(context.Background(), key, worklogID); err != nil {
+		return err
+	}
+
+	fmt.Printf("Worklog %s deleted from %s\n", worklogID, key)
+	return nil
+}

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -137,6 +137,15 @@ func runMCPServe(cmd *cobra.Command, args []string) error {
 	)
 
 	s.AddTool(
+		mcp.NewTool("jira_delete_worklog",
+			mcp.WithDescription("Delete a worklog entry from a Jira issue"),
+			mcp.WithString("key", mcp.Required(), mcp.Description("Issue key (e.g. ESA-123)")),
+			mcp.WithString("worklog_id", mcp.Required(), mcp.Description("Worklog ID")),
+		),
+		deleteWorklogHandler(jc),
+	)
+
+	s.AddTool(
 		mcp.NewTool("jira_add_comment",
 			mcp.WithDescription("Add a comment to a Jira issue"),
 			mcp.WithString("key", mcp.Required(), mcp.Description("Issue key (e.g. ESA-123)")),
@@ -559,6 +568,25 @@ func listWorklogsHandler(jc *client.Client) server.ToolHandlerFunc {
 		}
 
 		return mcp.NewToolResultText(toJSON(worklogs)), nil
+	}
+}
+
+func deleteWorklogHandler(jc *client.Client) server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		key, err := req.RequireString("key")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		worklogID, err := req.RequireString("worklog_id")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		if err := jc.DeleteWorklog(ctx, key, worklogID); err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		return mcp.NewToolResultText(fmt.Sprintf(`{"deleted": "%s", "issue": "%s"}`, worklogID, key)), nil
 	}
 }
 

--- a/internal/client/jira.go
+++ b/internal/client/jira.go
@@ -276,6 +276,13 @@ func (c *Client) GetWorklogs(ctx context.Context, key string) ([]models.Worklog,
 	return resp.Worklogs, nil
 }
 
+// DeleteWorklog removes a worklog entry from an issue.
+func (c *Client) DeleteWorklog(ctx context.Context, key, worklogID string) error {
+	path := "/issue/" + url.PathEscape(key) + "/worklog/" + url.PathEscape(worklogID)
+	_, err := c.do(ctx, http.MethodDelete, path, nil)
+	return err
+}
+
 // AddComment adds a comment to an issue.
 func (c *Client) AddComment(ctx context.Context, key string, req *models.AddCommentRequest) (*models.Comment, error) {
 	data, err := c.do(ctx, http.MethodPost, "/issue/"+url.PathEscape(key)+"/comment", req)


### PR DESCRIPTION
Closes #16.

## Summary

Adds a `worklog-delete` subcommand and matching MCP tool. Until now, removing a worklog required falling back to a raw `curl` against the Jira REST API.

## Changes

- `cmd/issue/worklog_delete.go` — new CLI command `jira8 issue worklog-delete ISSUE-KEY --id <worklogID> [--yes]`, with confirmation prompt by default and `--yes` to skip (mirrors `comment-delete` UX in #14).
- `cmd/issue/issue.go` — register the new subcommand.
- `cmd/mcp.go` — register `jira_delete_worklog` MCP tool with `key` + `worklog_id` parameters.
- `internal/client/jira.go` — `(*Client).DeleteWorklog(ctx, key, worklogID) error` calling `DELETE /rest/api/2/issue/{key}/worklog/{id}`.

CLI ↔ MCP parity preserved per `CLAUDE.md`.

## Test plan

- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] Manual smoke test against `jira.amplia.es`:
  - Created worklog `27707` on `ESA-153` via `worklog-add`.
  - Deleted with `jira8 issue worklog-delete ESA-153 --id 27707 --yes` → `Worklog 27707 deleted from ESA-153`.
  - `worklog-list` confirms it's gone.
- [x] `jira8 issue worklog-delete --help` shows expected usage and flags.