### PR TITLE
feat(mcp): expand resources and prompts for Claude

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,8 +204,11 @@ jira8 mcp serve
 | `jira_list_transitions` | List available transitions |
 | `jira_add_comment` | Add a comment |
 | `jira_list_comments` | List comments |
+| `jira_edit_comment` | Edit an existing comment |
+| `jira_delete_comment` | Delete a comment |
 | `jira_add_worklog` | Add a worklog entry |
 | `jira_list_worklogs` | List worklog entries |
+| `jira_delete_worklog` | Delete a worklog entry |
 | `jira_list_issue_types` | List issue types for a project |
 | `jira_list_statuses` | List statuses grouped by issue type |
 | `jira_list_priorities` | List available priorities |
@@ -225,6 +228,10 @@ Resources expose Jira data by URI. Clients that support them (Claude Code, Gemin
 | `jira://projects/{key}/types` | Issue types valid in a project |
 | `jira://projects/{key}/statuses` | Statuses grouped by issue type |
 | `jira://issues/{key}` | Full issue payload (includes raw custom fields) |
+| `jira://issues/{key}/comments` | Comment thread on an issue |
+| `jira://issues/{key}/worklogs` | Worklog entries on an issue |
+| `jira://issues/{key}/transitions` | Workflow transitions available right now |
+| `jira://epics/{key}/children` | Issues linked to an Epic via Epic Link |
 
 In Claude Code: reference them with `@jira:jira://...` in the prompt.
 
@@ -237,10 +244,17 @@ Prompts are reusable conversational templates. Claude Code surfaces them as `/mc
 | `triage_issue` | `key` | Loads an issue and asks for a structured triage (priority, missing info, labels, assignee) |
 | `create_bug_report` | `summary`, `steps_to_reproduce`, `expected_behavior`, `actual_behavior` (+ optional `environment`, `project`) | Builds a well-formed Bug report ready to file via `jira_create_issue` |
 | `epic_breakdown` | `epic_key` | Loads an Epic + its children and proposes missing stories/sub-tasks |
+| `summarise_comments` | `key` | Loads an issue's comment thread and extracts decisions, open questions and pending actions |
 
 ### Claude Code integration
 
-Add to your Claude Code MCP settings:
+Add the server with the `claude` CLI (recommended):
+
+```bash
+claude mcp add jira /path/to/jira8 mcp serve
+```
+
+Or, edit `.mcp.json` (project) / `~/.claude.json` (user) by hand:
 
 ```json
 {
@@ -252,6 +266,47 @@ Add to your Claude Code MCP settings:
   }
 }
 ```
+
+After adding, run `/mcp` inside Claude Code to verify the server shows up
+and lists tools, resources and prompts.
+
+### Claude Desktop integration
+
+Edit Claude Desktop's MCP config and add the same server entry:
+
+- macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+- Linux: `~/.config/Claude/claude_desktop_config.json`
+
+```json
+{
+  "mcpServers": {
+    "jira": {
+      "command": "/path/to/jira8",
+      "args": ["mcp", "serve"]
+    }
+  }
+}
+```
+
+Restart Claude Desktop after editing. The Jira tools, resources and prompts
+will appear in the connectors panel.
+
+> **Tip — credentials.** The MCP server inherits the same configuration as
+> the CLI: `~/.jira.yaml`, `JIRA_*` environment variables, or flags. To pass
+> credentials only to the MCP server, add an `env` block:
+>
+> ```json
+> {
+>   "mcpServers": {
+>     "jira": {
+>       "command": "/path/to/jira8",
+>       "args": ["mcp", "serve"],
+>       "env": { "JIRA_TOKEN": "...", "JIRA_URL": "https://jira.example.com/jira" }
+>     }
+>   }
+> }
+> ```
 
 ### Client support matrix
 

--- a/cmd/mcp_prompts.go
+++ b/cmd/mcp_prompts.go
@@ -50,6 +50,14 @@ func registerPrompts(s *server.MCPServer, jc *client.Client, defaultProject stri
 		),
 		epicBreakdownPromptHandler(jc),
 	)
+
+	s.AddPrompt(
+		mcp.NewPrompt("summarise_comments",
+			mcp.WithPromptDescription("Load the comment thread of an issue and summarise decisions, open questions and pending actions"),
+			mcp.WithArgument("key", mcp.RequiredArgument(), mcp.ArgumentDescription("Issue key whose comment thread should be summarised (e.g. ESA-123)")),
+		),
+		summariseCommentsPromptHandler(jc),
+	)
 }
 
 func triageIssuePromptHandler(jc *client.Client) server.PromptHandlerFunc {
@@ -179,6 +187,56 @@ func epicBreakdownPromptHandler(jc *client.Client) server.PromptHandlerFunc {
 			mcp.NewPromptMessage(mcp.RoleUser, mcp.NewTextContent(b.String()+"\n"+instructions)),
 		}
 		return mcp.NewGetPromptResult(fmt.Sprintf("Breakdown of Epic %s", key), messages), nil
+	}
+}
+
+func summariseCommentsPromptHandler(jc *client.Client) server.PromptHandlerFunc {
+	return func(ctx context.Context, req mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+		key := req.Params.Arguments["key"]
+		if key == "" {
+			return nil, fmt.Errorf("argument 'key' is required")
+		}
+
+		issue, err := jc.GetIssue(ctx, key)
+		if err != nil {
+			return nil, fmt.Errorf("loading %s: %w", key, err)
+		}
+		comments, err := jc.GetComments(ctx, key)
+		if err != nil {
+			return nil, fmt.Errorf("loading comments of %s: %w", key, err)
+		}
+
+		var b strings.Builder
+		b.WriteString(summariseIssueForPrompt(issue))
+		b.WriteString(fmt.Sprintf("\nComments (%d):\n", len(comments)))
+		if len(comments) == 0 {
+			b.WriteString("  (none)\n")
+		}
+		for _, c := range comments {
+			author := "?"
+			if c.Author != nil {
+				author = c.Author.DisplayName
+				if author == "" {
+					author = c.Author.Name
+				}
+			}
+			body := strings.ReplaceAll(c.Body, "\n", " ")
+			b.WriteString(fmt.Sprintf("  - [%s] %s — %s\n", c.Created, author, body))
+		}
+
+		instructions := strings.Join([]string{
+			"Summarise the comment thread above. Produce:",
+			"  1. Decisions taken (with the comment author and date that locked them in).",
+			"  2. Open questions that nobody has answered yet.",
+			"  3. Pending actions, with owner if mentioned.",
+			"  4. A one-line current status of the issue based purely on the thread.",
+			"Be terse. Quote literally only when the wording matters. If a section has nothing, write \"n/a\".",
+		}, "\n")
+
+		messages := []mcp.PromptMessage{
+			mcp.NewPromptMessage(mcp.RoleUser, mcp.NewTextContent(b.String()+"\n"+instructions)),
+		}
+		return mcp.NewGetPromptResult(fmt.Sprintf("Comment summary of %s", key), messages), nil
 	}
 }
 

--- a/cmd/mcp_prompts_test.go
+++ b/cmd/mcp_prompts_test.go
@@ -95,3 +95,52 @@ func TestTriageIssuePrompt_MissingKey(t *testing.T) {
 		t.Fatal("expected error on missing key, got nil")
 	}
 }
+
+func TestSummariseCommentsPrompt_EmbedsComments(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/rest/api/2/issue/TEST-1/comment"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"total": 2,
+				"comments": []map[string]any{
+					{"id": "1", "body": "we should ship friday", "created": "2026-04-29T10:00:00Z", "author": map[string]any{"displayName": "Alice"}},
+					{"id": "2", "body": "agreed, blocked on infra", "created": "2026-04-29T11:00:00Z", "author": map[string]any{"displayName": "Bob"}},
+				},
+			})
+		case strings.HasSuffix(r.URL.Path, "/rest/api/2/issue/TEST-1"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id": "1", "key": "TEST-1",
+				"fields": map[string]any{"summary": "Release prep"},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	jc := client.New(&config.Config{URL: srv.URL, Token: "x"})
+	handler := summariseCommentsPromptHandler(jc)
+	req := mcp.GetPromptRequest{}
+	req.Params.Arguments = map[string]string{"key": "TEST-1"}
+
+	res, err := handler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	tc := res.Messages[0].Content.(mcp.TextContent)
+	for _, want := range []string{"Release prep", "Alice", "Bob", "ship friday", "Decisions taken", "Open questions"} {
+		if !strings.Contains(tc.Text, want) {
+			t.Errorf("summarise_comments prompt missing %q in:\n%s", want, tc.Text)
+		}
+	}
+}
+
+func TestSummariseCommentsPrompt_MissingKey(t *testing.T) {
+	jc := client.New(&config.Config{URL: "http://unused", Token: "x"})
+	handler := summariseCommentsPromptHandler(jc)
+	req := mcp.GetPromptRequest{}
+	req.Params.Arguments = map[string]string{}
+	if _, err := handler(context.Background(), req); err == nil {
+		t.Fatal("expected error on missing key, got nil")
+	}
+}

--- a/cmd/mcp_resources.go
+++ b/cmd/mcp_resources.go
@@ -11,6 +11,10 @@ package cmd
 //   jira://projects/{key}/types             — issue types valid for a project
 //   jira://projects/{key}/statuses          — statuses grouped by issue type
 //   jira://issues/{key}                     — full issue payload (Jira raw JSON)
+//   jira://issues/{key}/comments            — comment thread on an issue
+//   jira://issues/{key}/worklogs            — worklog entries on an issue
+//   jira://issues/{key}/transitions         — workflow transitions available now
+//   jira://epics/{key}/children             — issues linked to an Epic
 //
 // Handlers return application/json so AI agents can parse without re-tokenising.
 
@@ -24,7 +28,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 )
 
-// registerResources installs the four jira:// resources/templates on s.
+// registerResources installs the jira:// resources/templates on s.
 func registerResources(s *server.MCPServer, jc *client.Client) {
 	s.AddResource(
 		mcp.NewResource(
@@ -64,6 +68,46 @@ func registerResources(s *server.MCPServer, jc *client.Client) {
 			mcp.WithTemplateMIMEType("application/json"),
 		),
 		issueResourceHandler(jc),
+	)
+
+	s.AddResourceTemplate(
+		mcp.NewResourceTemplate(
+			"jira://issues/{key}/comments",
+			"Issue comments",
+			mcp.WithTemplateDescription("Comment thread on a Jira issue, ordered as returned by Jira"),
+			mcp.WithTemplateMIMEType("application/json"),
+		),
+		issueCommentsResourceHandler(jc),
+	)
+
+	s.AddResourceTemplate(
+		mcp.NewResourceTemplate(
+			"jira://issues/{key}/worklogs",
+			"Issue worklogs",
+			mcp.WithTemplateDescription("Worklog entries logged against a Jira issue (author, duration, started date, comment)"),
+			mcp.WithTemplateMIMEType("application/json"),
+		),
+		issueWorklogsResourceHandler(jc),
+	)
+
+	s.AddResourceTemplate(
+		mcp.NewResourceTemplate(
+			"jira://issues/{key}/transitions",
+			"Issue transitions",
+			mcp.WithTemplateDescription("Workflow transitions available right now for an issue, given its current status"),
+			mcp.WithTemplateMIMEType("application/json"),
+		),
+		issueTransitionsResourceHandler(jc),
+	)
+
+	s.AddResourceTemplate(
+		mcp.NewResourceTemplate(
+			"jira://epics/{key}/children",
+			"Epic children",
+			mcp.WithTemplateDescription("Issues linked to an Epic via Epic Link (stories, sub-tasks, bugs)"),
+			mcp.WithTemplateMIMEType("application/json"),
+		),
+		epicChildrenResourceHandler(jc),
 	)
 }
 
@@ -116,6 +160,63 @@ func issueResourceHandler(jc *client.Client) server.ResourceTemplateHandlerFunc 
 			return nil, err
 		}
 		return jsonResource(req.Params.URI, issue)
+	}
+}
+
+func issueCommentsResourceHandler(jc *client.Client) server.ResourceTemplateHandlerFunc {
+	return func(ctx context.Context, req mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+		key, err := templateString(req, "key")
+		if err != nil {
+			return nil, err
+		}
+		comments, err := jc.GetComments(ctx, key)
+		if err != nil {
+			return nil, err
+		}
+		return jsonResource(req.Params.URI, comments)
+	}
+}
+
+func issueWorklogsResourceHandler(jc *client.Client) server.ResourceTemplateHandlerFunc {
+	return func(ctx context.Context, req mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+		key, err := templateString(req, "key")
+		if err != nil {
+			return nil, err
+		}
+		worklogs, err := jc.GetWorklogs(ctx, key)
+		if err != nil {
+			return nil, err
+		}
+		return jsonResource(req.Params.URI, worklogs)
+	}
+}
+
+func issueTransitionsResourceHandler(jc *client.Client) server.ResourceTemplateHandlerFunc {
+	return func(ctx context.Context, req mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+		key, err := templateString(req, "key")
+		if err != nil {
+			return nil, err
+		}
+		transitions, err := jc.GetTransitions(ctx, key)
+		if err != nil {
+			return nil, err
+		}
+		return jsonResource(req.Params.URI, transitions)
+	}
+}
+
+func epicChildrenResourceHandler(jc *client.Client) server.ResourceTemplateHandlerFunc {
+	return func(ctx context.Context, req mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+		key, err := templateString(req, "key")
+		if err != nil {
+			return nil, err
+		}
+		jql := client.BuildJQLWith(client.JQLFilters{Epic: key})
+		children, err := jc.SearchAllIssues(ctx, jql, 100)
+		if err != nil {
+			return nil, err
+		}
+		return jsonResource(req.Params.URI, children)
 	}
 }
 

--- a/cmd/mcp_resources_test.go
+++ b/cmd/mcp_resources_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
-// stubJiraServer serves a fixed priority list and a fixed issue, used to exercise
-// the resource handlers without touching a real Jira instance.
+// stubJiraServer serves canned data for the resource handlers without touching
+// a real Jira instance.
 func stubJiraServer(t *testing.T) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -23,6 +23,36 @@ func stubJiraServer(t *testing.T) *httptest.Server {
 			_ = json.NewEncoder(w).Encode([]map[string]any{
 				{"id": "1", "name": "Blocker"},
 				{"id": "2", "name": "Critical"},
+			})
+		case strings.HasSuffix(r.URL.Path, "/rest/api/2/issue/TEST-1/comment"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"total": 1,
+				"comments": []map[string]any{
+					{"id": "10", "body": "first comment", "author": map[string]any{"name": "alice"}},
+				},
+			})
+		case strings.HasSuffix(r.URL.Path, "/rest/api/2/issue/TEST-1/worklog"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"total": 1,
+				"worklogs": []map[string]any{
+					{"id": "20", "timeSpent": "1h", "comment": "fix"},
+				},
+			})
+		case strings.HasSuffix(r.URL.Path, "/rest/api/2/issue/TEST-1/transitions"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"transitions": []map[string]any{
+					{"id": "31", "name": "In Progress"},
+					{"id": "41", "name": "Done"},
+				},
+			})
+		case strings.HasSuffix(r.URL.Path, "/rest/api/2/search"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"startAt":    0,
+				"maxResults": 100,
+				"total":      1,
+				"issues": []map[string]any{
+					{"id": "1", "key": "TEST-2", "fields": map[string]any{"summary": "child"}},
+				},
 			})
 		case strings.HasSuffix(r.URL.Path, "/rest/api/2/issue/TEST-1"):
 			_ = json.NewEncoder(w).Encode(map[string]any{
@@ -127,5 +157,87 @@ func TestIssueResourceHandler(t *testing.T) {
 	}
 	if payload["key"] != "TEST-1" {
 		t.Errorf("expected key=TEST-1, got %v", payload["key"])
+	}
+}
+
+func TestIssueCommentsResourceHandler(t *testing.T) {
+	srv := stubJiraServer(t)
+	defer srv.Close()
+	jc := client.New(&config.Config{URL: srv.URL, Token: "x"})
+
+	handler := issueCommentsResourceHandler(jc)
+	req := mcp.ReadResourceRequest{}
+	req.Params.URI = "jira://issues/TEST-1/comments"
+	req.Params.Arguments = map[string]any{"key": []string{"TEST-1"}}
+
+	contents, err := handler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	trc := contents[0].(mcp.TextResourceContents)
+	if !strings.Contains(trc.Text, "first comment") {
+		t.Errorf("payload missing comment body: %q", trc.Text)
+	}
+}
+
+func TestIssueWorklogsResourceHandler(t *testing.T) {
+	srv := stubJiraServer(t)
+	defer srv.Close()
+	jc := client.New(&config.Config{URL: srv.URL, Token: "x"})
+
+	handler := issueWorklogsResourceHandler(jc)
+	req := mcp.ReadResourceRequest{}
+	req.Params.URI = "jira://issues/TEST-1/worklogs"
+	req.Params.Arguments = map[string]any{"key": []string{"TEST-1"}}
+
+	contents, err := handler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	trc := contents[0].(mcp.TextResourceContents)
+	if !strings.Contains(trc.Text, "1h") {
+		t.Errorf("payload missing worklog timeSpent: %q", trc.Text)
+	}
+}
+
+func TestIssueTransitionsResourceHandler(t *testing.T) {
+	srv := stubJiraServer(t)
+	defer srv.Close()
+	jc := client.New(&config.Config{URL: srv.URL, Token: "x"})
+
+	handler := issueTransitionsResourceHandler(jc)
+	req := mcp.ReadResourceRequest{}
+	req.Params.URI = "jira://issues/TEST-1/transitions"
+	req.Params.Arguments = map[string]any{"key": []string{"TEST-1"}}
+
+	contents, err := handler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	trc := contents[0].(mcp.TextResourceContents)
+	for _, want := range []string{"In Progress", "Done"} {
+		if !strings.Contains(trc.Text, want) {
+			t.Errorf("payload missing %q: %s", want, trc.Text)
+		}
+	}
+}
+
+func TestEpicChildrenResourceHandler(t *testing.T) {
+	srv := stubJiraServer(t)
+	defer srv.Close()
+	jc := client.New(&config.Config{URL: srv.URL, Token: "x"})
+
+	handler := epicChildrenResourceHandler(jc)
+	req := mcp.ReadResourceRequest{}
+	req.Params.URI = "jira://epics/TEST-1/children"
+	req.Params.Arguments = map[string]any{"key": []string{"TEST-1"}}
+
+	contents, err := handler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	trc := contents[0].(mcp.TextResourceContents)
+	if !strings.Contains(trc.Text, "TEST-2") {
+		t.Errorf("payload missing child issue key: %q", trc.Text)
 	}
 }


### PR DESCRIPTION
## Summary

- Add four new MCP resource templates: `jira://issues/{key}/comments`, `jira://issues/{key}/worklogs`, `jira://issues/{key}/transitions`, `jira://epics/{key}/children` — all backed by existing client methods (no new tools needed).
- Add `summarise_comments` MCP prompt that loads an issue's comment thread and extracts decisions, open questions and pending actions.
- Audit confirmed full CLI ↔ MCP parity (21 ↔ 21). README's tool table was missing the three v1.2.0 additions (`jira_edit_comment`, `jira_delete_comment`, `jira_delete_worklog`); this PR also fixes that.
- Expand README with explicit Claude Code (`claude mcp add`) and Claude Desktop setup sections (incl. paths for macOS/Windows/Linux and credentials tip).

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — all packages pass; new tests added for every new resource handler and the new prompt (success + missing-arg).
- [ ] Manual smoke against `jira.amplia.es`:
  - [ ] `@jira:jira://issues/<KEY>/comments` returns the thread
  - [ ] `@jira:jira://epics/<KEY>/children` returns the children
  - [ ] `/mcp__jira__summarise_comments key=<KEY>` produces a summary