### PR TITLE
feat: add opt-in Markdown to Jira Wiki conversion (CLI + MCP)

### DIFF
--- a/cmd/epic/create.go
+++ b/cmd/epic/create.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/amplia/jira8/cmd/app"
+	"github.com/amplia/jira8/internal/markup"
 	"github.com/amplia/jira8/internal/models"
 	"github.com/spf13/cobra"
 )
@@ -25,6 +26,7 @@ func init() {
 	createCmd.Flags().String("description", "", "Epic description")
 	createCmd.Flags().String("assignee", "", "Assignee username (use 'me' for current user)")
 	createCmd.Flags().String("priority", "", "Priority name")
+	createCmd.Flags().Bool("markdown", false, "Treat --description as Markdown and convert to Jira Wiki Markup before sending")
 
 	_ = createCmd.MarkFlagRequired("name")
 	_ = createCmd.MarkFlagRequired("summary")
@@ -40,6 +42,9 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		project = a.Config.Project
 	}
 	description, _ := cmd.Flags().GetString("description")
+	if md, _ := cmd.Flags().GetBool("markdown"); md {
+		description = markup.MarkdownToWiki(description)
+	}
 	assignee, _ := cmd.Flags().GetString("assignee")
 	priority, _ := cmd.Flags().GetString("priority")
 

--- a/cmd/epic/edit.go
+++ b/cmd/epic/edit.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/amplia/jira8/cmd/app"
+	"github.com/amplia/jira8/internal/markup"
 	"github.com/amplia/jira8/internal/models"
 	"github.com/spf13/cobra"
 )
@@ -24,6 +25,7 @@ func init() {
 	editCmd.Flags().String("description", "", "New description")
 	editCmd.Flags().String("assignee", "", "New assignee (use 'me' for current user, empty to unassign)")
 	editCmd.Flags().String("priority", "", "New priority")
+	editCmd.Flags().Bool("markdown", false, "Treat --description as Markdown and convert to Jira Wiki Markup before sending")
 }
 
 func runEdit(cmd *cobra.Command, args []string) error {
@@ -47,6 +49,9 @@ func runEdit(cmd *cobra.Command, args []string) error {
 	}
 	if cmd.Flags().Changed("description") {
 		v, _ := cmd.Flags().GetString("description")
+		if md, _ := cmd.Flags().GetBool("markdown"); md {
+			v = markup.MarkdownToWiki(v)
+		}
 		fields["description"] = v
 	}
 	if cmd.Flags().Changed("assignee") {

--- a/cmd/issue/comment_add.go
+++ b/cmd/issue/comment_add.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/amplia/jira8/cmd/app"
+	"github.com/amplia/jira8/internal/markup"
 	"github.com/amplia/jira8/internal/models"
 	"github.com/spf13/cobra"
 )
@@ -21,6 +22,7 @@ var commentAddCmd = &cobra.Command{
 
 func init() {
 	commentAddCmd.Flags().String("body", "", "Comment body (required)")
+	commentAddCmd.Flags().Bool("markdown", false, "Treat --body as Markdown and convert to Jira Wiki Markup before sending")
 	_ = commentAddCmd.MarkFlagRequired("body")
 }
 
@@ -29,6 +31,9 @@ func runCommentAdd(cmd *cobra.Command, args []string) error {
 	key := args[0]
 
 	body, _ := cmd.Flags().GetString("body")
+	if md, _ := cmd.Flags().GetBool("markdown"); md {
+		body = markup.MarkdownToWiki(body)
+	}
 
 	comment, err := a.Client.AddComment(context.Background(), key, &models.AddCommentRequest{
 		Body: body,

--- a/cmd/issue/comment_edit.go
+++ b/cmd/issue/comment_edit.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/amplia/jira8/cmd/app"
+	"github.com/amplia/jira8/internal/markup"
 	"github.com/spf13/cobra"
 )
 
@@ -21,6 +22,7 @@ var commentEditCmd = &cobra.Command{
 func init() {
 	commentEditCmd.Flags().String("id", "", "Comment ID (required)")
 	commentEditCmd.Flags().String("body", "", "Updated comment body (required)")
+	commentEditCmd.Flags().Bool("markdown", false, "Treat --body as Markdown and convert to Jira Wiki Markup before sending")
 	_ = commentEditCmd.MarkFlagRequired("id")
 	_ = commentEditCmd.MarkFlagRequired("body")
 }
@@ -31,6 +33,9 @@ func runCommentEdit(cmd *cobra.Command, args []string) error {
 
 	commentID, _ := cmd.Flags().GetString("id")
 	body, _ := cmd.Flags().GetString("body")
+	if md, _ := cmd.Flags().GetBool("markdown"); md {
+		body = markup.MarkdownToWiki(body)
+	}
 
 	comment, err := a.Client.EditComment(context.Background(), key, commentID, body)
 	if err != nil {

--- a/cmd/issue/create.go
+++ b/cmd/issue/create.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/amplia/jira8/cmd/app"
+	"github.com/amplia/jira8/internal/markup"
 	"github.com/amplia/jira8/internal/models"
 	"github.com/spf13/cobra"
 )
@@ -28,6 +29,7 @@ func init() {
 	createCmd.Flags().String("parent", "", "Parent issue key for Sub-task creation (e.g. ESA-65)")
 	createCmd.Flags().String("epic-name", "", "Epic Name (required when --type Epic)")
 	createCmd.Flags().String("epic-link", "", "Epic key to associate this issue with (e.g. ESA-42)")
+	createCmd.Flags().Bool("markdown", false, "Treat --description as Markdown and convert to Jira Wiki Markup before sending")
 
 	_ = createCmd.MarkFlagRequired("summary")
 }
@@ -42,6 +44,9 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		project = a.Config.Project
 	}
 	description, _ := cmd.Flags().GetString("description")
+	if md, _ := cmd.Flags().GetBool("markdown"); md {
+		description = markup.MarkdownToWiki(description)
+	}
 	assignee, _ := cmd.Flags().GetString("assignee")
 	priority, _ := cmd.Flags().GetString("priority")
 	parent, _ := cmd.Flags().GetString("parent")

--- a/cmd/issue/edit.go
+++ b/cmd/issue/edit.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/amplia/jira8/cmd/app"
+	"github.com/amplia/jira8/internal/markup"
 	"github.com/amplia/jira8/internal/models"
 	"github.com/spf13/cobra"
 )
@@ -25,6 +26,7 @@ func init() {
 	editCmd.Flags().String("priority", "", "New priority")
 	editCmd.Flags().String("epic-name", "", "New Epic Name (only valid on Epic issues)")
 	editCmd.Flags().String("epic-link", "", "Epic key to associate this issue with (empty to detach)")
+	editCmd.Flags().Bool("markdown", false, "Treat --description as Markdown and convert to Jira Wiki Markup before sending")
 }
 
 func runEdit(cmd *cobra.Command, args []string) error {
@@ -40,6 +42,9 @@ func runEdit(cmd *cobra.Command, args []string) error {
 
 	if cmd.Flags().Changed("description") {
 		v, _ := cmd.Flags().GetString("description")
+		if md, _ := cmd.Flags().GetBool("markdown"); md {
+			v = markup.MarkdownToWiki(v)
+		}
 		fields["description"] = v
 	}
 

--- a/cmd/issue/worklog_add.go
+++ b/cmd/issue/worklog_add.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/amplia/jira8/cmd/app"
+	"github.com/amplia/jira8/internal/markup"
 	"github.com/amplia/jira8/internal/models"
 	"github.com/spf13/cobra"
 )
@@ -24,6 +25,7 @@ func init() {
 	worklogAddCmd.Flags().String("time", "", "Time spent (e.g., 2h, 30m, 1d) (required)")
 	worklogAddCmd.Flags().String("date", "", "Start date/time in ISO 8601 (optional, defaults to now)")
 	worklogAddCmd.Flags().String("comment", "", "Worklog comment (optional)")
+	worklogAddCmd.Flags().Bool("markdown", false, "Treat --comment as Markdown and convert to Jira Wiki Markup before sending")
 	_ = worklogAddCmd.MarkFlagRequired("time")
 }
 
@@ -34,6 +36,9 @@ func runWorklogAdd(cmd *cobra.Command, args []string) error {
 	timeSpent, _ := cmd.Flags().GetString("time")
 	started, _ := cmd.Flags().GetString("date")
 	comment, _ := cmd.Flags().GetString("comment")
+	if md, _ := cmd.Flags().GetBool("markdown"); md && comment != "" {
+		comment = markup.MarkdownToWiki(comment)
+	}
 
 	req := &models.AddWorklogRequest{
 		TimeSpent: timeSpent,

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/amplia/jira8/cmd/app"
 	"github.com/amplia/jira8/internal/client"
+	"github.com/amplia/jira8/internal/markup"
 	"github.com/amplia/jira8/internal/models"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -82,6 +83,7 @@ func runMCPServe(cmd *cobra.Command, args []string) error {
 			mcp.WithString("parent", mcp.Description("Parent issue key for Sub-task creation (e.g. ESA-65)")),
 			mcp.WithString("epic_name", mcp.Description("Epic Name (required when type is Epic)")),
 			mcp.WithString("epic_link", mcp.Description("Epic key to associate this issue with (e.g. ESA-42)")),
+			mcp.WithString("format", mcp.Description(formatParamDescription)),
 		),
 		createIssueHandler(jc),
 	)
@@ -96,6 +98,7 @@ func runMCPServe(cmd *cobra.Command, args []string) error {
 			mcp.WithString("priority", mcp.Description("New priority name")),
 			mcp.WithString("epic_name", mcp.Description("New Epic Name (only for Epics)")),
 			mcp.WithString("epic_link", mcp.Description("New Epic key to link to (empty string to detach)")),
+			mcp.WithString("format", mcp.Description(formatParamDescription)),
 		),
 		editIssueHandler(jc),
 	)
@@ -124,6 +127,7 @@ func runMCPServe(cmd *cobra.Command, args []string) error {
 			mcp.WithString("time", mcp.Required(), mcp.Description("Time spent (e.g., 2h, 30m, 1d)")),
 			mcp.WithString("date", mcp.Description("Start date/time in ISO 8601 (optional, defaults to now)")),
 			mcp.WithString("comment", mcp.Description("Worklog comment")),
+			mcp.WithString("format", mcp.Description(formatParamDescription)),
 		),
 		addWorklogHandler(jc),
 	)
@@ -150,6 +154,7 @@ func runMCPServe(cmd *cobra.Command, args []string) error {
 			mcp.WithDescription("Add a comment to a Jira issue"),
 			mcp.WithString("key", mcp.Required(), mcp.Description("Issue key (e.g. ESA-123)")),
 			mcp.WithString("body", mcp.Required(), mcp.Description("Comment body text")),
+			mcp.WithString("format", mcp.Description(formatParamDescription)),
 		),
 		addCommentHandler(jc),
 	)
@@ -167,7 +172,8 @@ func runMCPServe(cmd *cobra.Command, args []string) error {
 			mcp.WithDescription("Edit an existing comment on a Jira issue"),
 			mcp.WithString("key", mcp.Required(), mcp.Description("Issue key (e.g. ESA-123)")),
 			mcp.WithString("comment_id", mcp.Required(), mcp.Description("Comment ID")),
-			mcp.WithString("body", mcp.Required(), mcp.Description("Updated comment body (wiki markup)")),
+			mcp.WithString("body", mcp.Required(), mcp.Description("Updated comment body (wiki markup unless format=markdown)")),
+			mcp.WithString("format", mcp.Description(formatParamDescription)),
 		),
 		editCommentHandler(jc),
 	)
@@ -232,6 +238,7 @@ func runMCPServe(cmd *cobra.Command, args []string) error {
 			mcp.WithString("description", mcp.Description("Epic description")),
 			mcp.WithString("assignee", mcp.Description("Assignee username (use 'me' for current user)")),
 			mcp.WithString("priority", mcp.Description("Priority name")),
+			mcp.WithString("format", mcp.Description(formatParamDescription)),
 		),
 		createEpicHandler(jc),
 	)
@@ -245,6 +252,7 @@ func runMCPServe(cmd *cobra.Command, args []string) error {
 			mcp.WithString("description", mcp.Description("New description")),
 			mcp.WithString("assignee", mcp.Description("New assignee username (empty to unassign)")),
 			mcp.WithString("priority", mcp.Description("New priority name")),
+			mcp.WithString("format", mcp.Description(formatParamDescription)),
 		),
 		editEpicHandler(jc),
 	)
@@ -261,6 +269,23 @@ func runMCPServe(cmd *cobra.Command, args []string) error {
 
 	return server.ServeStdio(s)
 }
+
+// maybeConvertMarkdown returns text converted from Markdown to Jira Wiki
+// Markup when the MCP `format` argument is "markdown" (case-insensitive). Any
+// other value (default "wiki") returns the text unchanged. Used by tools that
+// accept free-form rich text (description, comment body, worklog comment) so
+// AI agents emitting Markdown natively can opt into conversion per-call.
+func maybeConvertMarkdown(text, format string) string {
+	if text == "" {
+		return text
+	}
+	if strings.EqualFold(format, "markdown") {
+		return markup.MarkdownToWiki(text)
+	}
+	return text
+}
+
+const formatParamDescription = `Input format for free-form text fields ("wiki" default, or "markdown" to convert from Markdown to Jira Wiki Markup before sending)`
 
 func toJSON(v any) string {
 	data, err := json.MarshalIndent(v, "", "  ")
@@ -334,12 +359,13 @@ func createIssueHandler(jc *client.Client) server.ToolHandlerFunc {
 			return mcp.NewToolResultError("epic_name only applies when type is Epic"), nil
 		}
 
+		format := req.GetString("format", "")
 		createReq := &models.CreateIssueRequest{
 			Fields: models.CreateIssueFields{
 				Project:     models.ProjectRef{Key: project},
 				Summary:     summary,
 				IssueType:   models.TypeRef{Name: issueType},
-				Description: req.GetString("description", ""),
+				Description: maybeConvertMarkdown(req.GetString("description", ""), format),
 			},
 		}
 
@@ -394,13 +420,15 @@ func editIssueHandler(jc *client.Client) server.ToolHandlerFunc {
 		}
 
 		args := req.GetArguments()
+		format := req.GetString("format", "")
 		fields := make(map[string]any)
 
 		if v, ok := args["summary"]; ok {
 			fields["summary"] = v
 		}
 		if v, ok := args["description"]; ok {
-			fields["description"] = v
+			s, _ := v.(string)
+			fields["description"] = maybeConvertMarkdown(s, format)
 		}
 		if v, ok := args["assignee"]; ok {
 			assignee, _ := v.(string)
@@ -562,7 +590,7 @@ func addWorklogHandler(jc *client.Client) server.ToolHandlerFunc {
 		wlReq := &models.AddWorklogRequest{
 			TimeSpent: timeSpent,
 			Started:   req.GetString("date", ""),
-			Comment:   req.GetString("comment", ""),
+			Comment:   maybeConvertMarkdown(req.GetString("comment", ""), req.GetString("format", "")),
 		}
 
 		wl, err := jc.AddWorklog(ctx, key, wlReq)
@@ -619,6 +647,7 @@ func addCommentHandler(jc *client.Client) server.ToolHandlerFunc {
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
+		body = maybeConvertMarkdown(body, req.GetString("format", ""))
 
 		comment, err := jc.AddComment(ctx, key, &models.AddCommentRequest{Body: body})
 		if err != nil {
@@ -659,6 +688,7 @@ func editCommentHandler(jc *client.Client) server.ToolHandlerFunc {
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
+		body = maybeConvertMarkdown(body, req.GetString("format", ""))
 
 		comment, err := jc.EditComment(ctx, key, commentID, body)
 		if err != nil {
@@ -774,7 +804,7 @@ func createEpicHandler(jc *client.Client) server.ToolHandlerFunc {
 				Project:     models.ProjectRef{Key: project},
 				Summary:     summary,
 				IssueType:   models.TypeRef{Name: "Epic"},
-				Description: req.GetString("description", ""),
+				Description: maybeConvertMarkdown(req.GetString("description", ""), req.GetString("format", "")),
 				Extra:       map[string]any{epicNameID: name},
 			},
 		}
@@ -812,6 +842,7 @@ func editEpicHandler(jc *client.Client) server.ToolHandlerFunc {
 		}
 
 		args := req.GetArguments()
+		format := req.GetString("format", "")
 		fields := make(map[string]any)
 
 		if v, ok := args["name"]; ok {
@@ -826,7 +857,8 @@ func editEpicHandler(jc *client.Client) server.ToolHandlerFunc {
 			fields["summary"] = v
 		}
 		if v, ok := args["description"]; ok {
-			fields["description"] = v
+			s, _ := v.(string)
+			fields["description"] = maybeConvertMarkdown(s, format)
 		}
 		if v, ok := args["assignee"]; ok {
 			assignee, _ := v.(string)

--- a/internal/markup/markup.go
+++ b/internal/markup/markup.go
@@ -1,0 +1,263 @@
+// Package markup converts a (small) subset of CommonMark-style Markdown into
+// Jira Server 8 Wiki Markup, the format expected by `description`, comment
+// `body`, and worklog `comment` fields.
+//
+// Conversion is line-based: headings, lists, blockquotes, tables, and fenced
+// code blocks are detected per-line. Inline transformations (bold, italic,
+// strikethrough, inline code, links) are then applied to lines that are not
+// inside a fenced code block.
+//
+// AI agent context: this is an opt-in conversion. Callers that already produce
+// Wiki Markup should not pass the input through MarkdownToWiki — the converter
+// is not idempotent (e.g. a Wiki `*bold*` looks like Markdown italic and would
+// be wrapped in `_..._`).
+package markup
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// MarkdownToWiki converts a Markdown string into Jira Server 8 Wiki Markup.
+// Empty input returns the empty string unchanged.
+func MarkdownToWiki(s string) string {
+	if s == "" {
+		return ""
+	}
+
+	lines := strings.Split(s, "\n")
+	out := make([]string, 0, len(lines))
+
+	inFence := false
+	inTable := false
+
+	for i := 0; i < len(lines); i++ {
+		line := lines[i]
+
+		if m := fenceLineRe.FindStringSubmatch(line); m != nil {
+			if !inFence {
+				inFence = true
+				lang := strings.TrimSpace(m[1])
+				if lang != "" {
+					out = append(out, "{code:"+lang+"}")
+				} else {
+					out = append(out, "{code}")
+				}
+			} else {
+				inFence = false
+				out = append(out, "{code}")
+			}
+			continue
+		}
+		if inFence {
+			out = append(out, line)
+			continue
+		}
+
+		if !inTable && isTableRow(line) && i+1 < len(lines) && isTableSeparator(lines[i+1]) {
+			cells := splitTableRow(line)
+			for j, c := range cells {
+				cells[j] = transformInline(c)
+			}
+			out = append(out, "||"+strings.Join(cells, "||")+"||")
+			i++ // skip separator row
+			inTable = true
+			continue
+		}
+		if inTable {
+			if isTableRow(line) {
+				cells := splitTableRow(line)
+				for j, c := range cells {
+					cells[j] = transformInline(c)
+				}
+				out = append(out, "|"+strings.Join(cells, "|")+"|")
+				continue
+			}
+			inTable = false
+		}
+
+		if isHorizontalRule(line) {
+			out = append(out, "----")
+			continue
+		}
+
+		if rest, ok := strings.CutPrefix(line, "> "); ok {
+			out = append(out, "bq. "+transformInline(rest))
+			continue
+		}
+		if strings.TrimRight(line, " \t") == ">" {
+			out = append(out, "bq. ")
+			continue
+		}
+
+		if m := headingRe.FindStringSubmatch(line); m != nil {
+			level := len(m[1])
+			out = append(out, fmt.Sprintf("h%d. %s", level, transformInline(m[2])))
+			continue
+		}
+
+		if m := bulletListRe.FindStringSubmatch(line); m != nil {
+			depth := indentDepth(m[1])
+			out = append(out, strings.Repeat("*", depth)+" "+transformInline(m[2]))
+			continue
+		}
+		if m := orderedListRe.FindStringSubmatch(line); m != nil {
+			depth := indentDepth(m[1])
+			out = append(out, strings.Repeat("#", depth)+" "+transformInline(m[2]))
+			continue
+		}
+
+		out = append(out, transformInline(line))
+	}
+
+	return strings.Join(out, "\n")
+}
+
+// indentDepth maps a leading-whitespace string to a 1-based list depth.
+// Two spaces (or one tab) per nesting level — the convention emitted by most
+// LLMs and what `prettier --prose-wrap` uses by default.
+func indentDepth(indent string) int {
+	spaces := 0
+	for _, r := range indent {
+		switch r {
+		case ' ':
+			spaces++
+		case '\t':
+			spaces += 2
+		}
+	}
+	return spaces/2 + 1
+}
+
+var (
+	fenceLineRe   = regexp.MustCompile("^```([A-Za-z0-9_+\\-]*)\\s*$")
+	headingRe     = regexp.MustCompile(`^(#{1,6})\s+(.*)$`)
+	bulletListRe  = regexp.MustCompile(`^([ \t]*)[-*+]\s+(.*)$`)
+	orderedListRe = regexp.MustCompile(`^([ \t]*)\d+\.\s+(.*)$`)
+	tableSeparatorCellRe = regexp.MustCompile(`^:?-{3,}:?$`)
+
+	inlineCodeRe  = regexp.MustCompile("`([^`\n]+)`")
+	boldStarRe    = regexp.MustCompile(`\*\*([^*\n]+)\*\*`)
+	boldUnderRe   = regexp.MustCompile(`__([^_\n]+)__`)
+	italicStarRe  = regexp.MustCompile(`\*([^*\n]+)\*`)
+	italicUnderRe = regexp.MustCompile(`(^|\W)_([^_\n]+)_(\W|$)`)
+	strikeRe      = regexp.MustCompile(`~~([^~\n]+)~~`)
+	linkRe        = regexp.MustCompile(`\[([^\]]+)\]\(([^)\s]+)\)`)
+
+	codePlaceholderRe = regexp.MustCompile(`\x00C(\d+)\x00`)
+	boldPlaceholderRe = regexp.MustCompile(`\x00B(\d+)\x00`)
+)
+
+// transformInline applies inline conversions to a single line of text. Inline
+// code spans are extracted to placeholders first so their content is not
+// re-processed; bold spans are also placeholdered so the italic pass can use
+// simple regexes without worrying about `**bold**` vs `*italic*` ambiguity.
+func transformInline(s string) string {
+	if s == "" {
+		return s
+	}
+
+	var codes []string
+	s = inlineCodeRe.ReplaceAllStringFunc(s, func(m string) string {
+		inner := m[1 : len(m)-1]
+		idx := len(codes)
+		codes = append(codes, inner)
+		return fmt.Sprintf("\x00C%d\x00", idx)
+	})
+
+	var bolds []string
+	stash := func(m string, marker int) string {
+		inner := m[marker : len(m)-marker]
+		idx := len(bolds)
+		bolds = append(bolds, inner)
+		return fmt.Sprintf("\x00B%d\x00", idx)
+	}
+	s = boldStarRe.ReplaceAllStringFunc(s, func(m string) string { return stash(m, 2) })
+	s = boldUnderRe.ReplaceAllStringFunc(s, func(m string) string { return stash(m, 2) })
+
+	s = italicStarRe.ReplaceAllString(s, "_${1}_")
+	s = italicUnderRe.ReplaceAllString(s, "${1}_${2}_${3}")
+
+	s = strikeRe.ReplaceAllString(s, "-${1}-")
+	s = linkRe.ReplaceAllString(s, "[${1}|${2}]")
+
+	s = boldPlaceholderRe.ReplaceAllStringFunc(s, func(m string) string {
+		var idx int
+		fmt.Sscanf(m, "\x00B%d\x00", &idx)
+		return "*" + bolds[idx] + "*"
+	})
+	s = codePlaceholderRe.ReplaceAllStringFunc(s, func(m string) string {
+		var idx int
+		fmt.Sscanf(m, "\x00C%d\x00", &idx)
+		return "{{" + codes[idx] + "}}"
+	})
+
+	return s
+}
+
+// isHorizontalRule reports whether the line is a Markdown thematic break:
+// three or more `-`, `_`, or `*` of the same kind, optionally separated by
+// spaces. Go's RE2 regexp engine has no backreferences, so this is a
+// hand-rolled check rather than a regex.
+func isHorizontalRule(line string) bool {
+	t := strings.TrimSpace(line)
+	if len(t) < 3 {
+		return false
+	}
+	first := t[0]
+	if first != '-' && first != '_' && first != '*' {
+		return false
+	}
+	count := 0
+	for i := 0; i < len(t); i++ {
+		switch t[i] {
+		case first:
+			count++
+		case ' ', '\t':
+			// allowed separator between markers
+		default:
+			return false
+		}
+	}
+	return count >= 3
+}
+
+func isTableRow(s string) bool {
+	t := strings.TrimSpace(s)
+	if !strings.Contains(t, "|") {
+		return false
+	}
+	return strings.HasPrefix(t, "|") || strings.HasSuffix(t, "|")
+}
+
+func isTableSeparator(s string) bool {
+	t := strings.TrimSpace(s)
+	if t == "" {
+		return false
+	}
+	t = strings.TrimPrefix(t, "|")
+	t = strings.TrimSuffix(t, "|")
+	parts := strings.Split(t, "|")
+	if len(parts) == 0 {
+		return false
+	}
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if !tableSeparatorCellRe.MatchString(p) {
+			return false
+		}
+	}
+	return true
+}
+
+func splitTableRow(s string) []string {
+	t := strings.TrimSpace(s)
+	t = strings.TrimPrefix(t, "|")
+	t = strings.TrimSuffix(t, "|")
+	parts := strings.Split(t, "|")
+	for i, p := range parts {
+		parts[i] = strings.TrimSpace(p)
+	}
+	return parts
+}

--- a/internal/markup/markup_test.go
+++ b/internal/markup/markup_test.go
@@ -1,0 +1,119 @@
+package markup
+
+import "testing"
+
+func TestMarkdownToWiki(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"plain", "just text", "just text"},
+
+		{"h1", "# Title", "h1. Title"},
+		{"h3", "### Section", "h3. Section"},
+		{"h6", "###### Tiny", "h6. Tiny"},
+		{"too-deep heading is plain", "####### Plain", "####### Plain"},
+
+		{"bold star", "this is **bold** here", "this is *bold* here"},
+		{"bold underscore", "this is __bold__ here", "this is *bold* here"},
+		{"italic star", "this is *italic* here", "this is _italic_ here"},
+		{"italic underscore", "this is _italic_ here", "this is _italic_ here"},
+		{"strikethrough", "~~gone~~", "-gone-"},
+		{"inline code", "use `make build`", "use {{make build}}"},
+		{"link", "see [docs](https://example.com)", "see [docs|https://example.com]"},
+
+		{"bold then italic", "**bold** and *italic*", "*bold* and _italic_"},
+		{
+			"underscore inside identifier is not italic",
+			"call my_helper_func",
+			"call my_helper_func",
+		},
+
+		{
+			"fenced code preserves content",
+			"before\n```go\nfunc f() {}\n```\nafter",
+			"before\n{code:go}\nfunc f() {}\n{code}\nafter",
+		},
+		{
+			"fenced code without lang",
+			"```\nplain text\n```",
+			"{code}\nplain text\n{code}",
+		},
+		{
+			"markdown markers inside fence are NOT transformed",
+			"```\n**not bold**\n# not heading\n```",
+			"{code}\n**not bold**\n# not heading\n{code}",
+		},
+
+		{
+			"unordered list",
+			"- one\n- two\n- three",
+			"* one\n* two\n* three",
+		},
+		{
+			"nested unordered list",
+			"- one\n  - one.a\n  - one.b\n- two",
+			"* one\n** one.a\n** one.b\n* two",
+		},
+		{
+			"ordered list",
+			"1. first\n2. second\n3. third",
+			"# first\n# second\n# third",
+		},
+		{
+			"mixed list with asterisk bullets",
+			"* a\n* b",
+			"* a\n* b",
+		},
+
+		{
+			"blockquote single line",
+			"> quoted text",
+			"bq. quoted text",
+		},
+		{
+			"blockquote with markdown inline",
+			"> **important** note",
+			"bq. *important* note",
+		},
+
+		{
+			"horizontal rule dashes",
+			"above\n\n---\n\nbelow",
+			"above\n\n----\n\nbelow",
+		},
+		{
+			"horizontal rule asterisks",
+			"***",
+			"----",
+		},
+
+		{
+			"table basic",
+			"| Name | Role |\n|------|------|\n| Alice | dev |\n| Bob | ops |",
+			"||Name||Role||\n|Alice|dev|\n|Bob|ops|",
+		},
+		{
+			"table with inline formatting",
+			"| Field | Value |\n|-------|-------|\n| `id` | **42** |",
+			"||Field||Value||\n|{{id}}|*42*|",
+		},
+
+		{
+			"complex mixed document",
+			"# Plan\n\nWe need to ship **soon**.\n\n- spec the `API`\n- write tests\n\n```go\nfunc main() {}\n```\n\nSee [tracker](https://example.com).",
+			"h1. Plan\n\nWe need to ship *soon*.\n\n* spec the {{API}}\n* write tests\n\n{code:go}\nfunc main() {}\n{code}\n\nSee [tracker|https://example.com].",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := MarkdownToWiki(tc.in)
+			if got != tc.want {
+				t.Errorf("MarkdownToWiki(%q)\n  got  %q\n  want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- New \`internal/markup\` package converts Markdown to Jira Server 8 Wiki Markup (headings, bold/italic/strike, inline code, fenced code, nested lists, blockquotes, HR, tables, links).
- CLI: \`--markdown\` flag added to \`issue create/edit\`, \`epic create/edit\`, \`issue comment-add/comment-edit\`, \`issue worklog-add\`.
- MCP: \`format\` parameter (\`\"wiki\"\` default, \`\"markdown\"\` to convert) added to \`jira_create_issue\`, \`jira_edit_issue\`, \`jira_create_epic\`, \`jira_edit_epic\`, \`jira_add_comment\`, \`jira_edit_comment\`, \`jira_add_worklog\`.

Closes #19.

## Scope intentionally out
Per the roadmap discussion, the following were filed as separate issues to keep this PR small:
- \`--description-file\` / stdin (#20)
- \`--preview\` / \`--dry-run\` (#21)
- Auto-upload of local image references as attachments (#22)
- Markdown image \`![alt](url)\` → Wiki \`!url!\` syntax (covered by #22)
- Task lists / footnotes fallbacks

## Parity
CLI subcommand ↔ MCP tool kept symmetrical per \`CLAUDE.md\`. Helper \`maybeConvertMarkdown(text, format)\` centralizes the conversion call site in MCP handlers.

## Test plan
- [x] \`go vet ./...\` clean.
- [x] \`go test ./...\` green (25 new table-driven cases in \`internal/markup\`).
- [x] \`go build .\` succeeds.
- [x] \`jira8 issue create --help\` (and the other 6 commands) shows the \`--markdown\` flag.
- [ ] Manual smoke against the Amplía Jira instance: create an issue with \`--description-file foo.md --markdown\` (deferred — depends on #20).
- [ ] Manual smoke via MCP: call \`jira_add_comment\` with \`format=markdown\` and verify rendering in Jira UI.