### PR TITLE
feat: add Wiki to Markdown conversion on read commands (CLI + MCP)

### DIFF
--- a/cmd/app/render.go
+++ b/cmd/app/render.go
@@ -1,0 +1,77 @@
+package app
+
+import (
+	"encoding/json"
+
+	"github.com/amplia/jira8/internal/markup"
+	"github.com/amplia/jira8/internal/models"
+)
+
+// RenderIssueAsMarkdown converts the description and any embedded comment
+// bodies of an issue from Jira Wiki Markup to Markdown in place. Used by read
+// commands and tools when the user has opted in via --markdown / format=markdown.
+//
+// IssueFields.MarshalJSON re-emits the raw payload received from Jira to
+// preserve custom fields, so we also overwrite the relevant entries in Raw
+// whenever it is populated; otherwise the JSON output would still contain the
+// original Wiki Markup despite the typed fields being converted.
+func RenderIssueAsMarkdown(issue *models.Issue) {
+	if issue == nil {
+		return
+	}
+	issue.Fields.Description = markup.WikiToMarkdown(issue.Fields.Description)
+	if issue.Fields.Comment != nil {
+		for i := range issue.Fields.Comment.Comments {
+			issue.Fields.Comment.Comments[i].Body = markup.WikiToMarkdown(issue.Fields.Comment.Comments[i].Body)
+		}
+	}
+	syncRawWithTyped(&issue.Fields)
+}
+
+// RenderIssuesAsMarkdown applies RenderIssueAsMarkdown to every entry in the
+// slice. Mutates in place.
+func RenderIssuesAsMarkdown(issues []models.Issue) {
+	for i := range issues {
+		RenderIssueAsMarkdown(&issues[i])
+	}
+}
+
+// RenderCommentsAsMarkdown converts each comment body in the slice from Jira
+// Wiki Markup to Markdown in place.
+func RenderCommentsAsMarkdown(comments []models.Comment) {
+	for i := range comments {
+		comments[i].Body = markup.WikiToMarkdown(comments[i].Body)
+	}
+}
+
+// RenderWorklogsAsMarkdown converts each worklog comment in the slice from
+// Jira Wiki Markup to Markdown in place.
+func RenderWorklogsAsMarkdown(worklogs []models.Worklog) {
+	for i := range worklogs {
+		worklogs[i].Comment = markup.WikiToMarkdown(worklogs[i].Comment)
+	}
+}
+
+// syncRawWithTyped overwrites the description and comment entries in
+// IssueFields.Raw with the current typed values. No-op when Raw is empty
+// (synthetic instances are marshalled from typed fields directly).
+func syncRawWithTyped(f *models.IssueFields) {
+	if len(f.Raw) == 0 {
+		return
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(f.Raw, &raw); err != nil {
+		return
+	}
+	if b, err := json.Marshal(f.Description); err == nil {
+		raw["description"] = b
+	}
+	if f.Comment != nil {
+		if b, err := json.Marshal(f.Comment); err == nil {
+			raw["comment"] = b
+		}
+	}
+	if newRaw, err := json.Marshal(raw); err == nil {
+		f.Raw = newRaw
+	}
+}

--- a/cmd/epic/children.go
+++ b/cmd/epic/children.go
@@ -20,6 +20,7 @@ var childrenCmd = &cobra.Command{
 
 func init() {
 	childrenCmd.Flags().Int("max", 100, "Maximum number of results")
+	childrenCmd.Flags().Bool("markdown", false, "Convert description fields from Jira Wiki Markup to Markdown")
 }
 
 func runChildren(cmd *cobra.Command, args []string) error {
@@ -31,6 +32,10 @@ func runChildren(cmd *cobra.Command, args []string) error {
 	issues, err := a.Client.SearchAllIssues(context.Background(), jql, max)
 	if err != nil {
 		return err
+	}
+
+	if md, _ := cmd.Flags().GetBool("markdown"); md {
+		app.RenderIssuesAsMarkdown(issues)
 	}
 
 	if a.Output == "json" {

--- a/cmd/epic/list.go
+++ b/cmd/epic/list.go
@@ -22,6 +22,7 @@ func init() {
 	listCmd.Flags().String("project", "", "Project key (default from config)")
 	listCmd.Flags().String("status", "", "Filter by status")
 	listCmd.Flags().Int("max", 50, "Maximum number of results")
+	listCmd.Flags().Bool("markdown", false, "Convert description fields from Jira Wiki Markup to Markdown")
 }
 
 func runList(cmd *cobra.Command, args []string) error {
@@ -51,6 +52,10 @@ func runList(cmd *cobra.Command, args []string) error {
 	issues, err := a.Client.SearchAllIssues(context.Background(), jql, max, extra...)
 	if err != nil {
 		return err
+	}
+
+	if md, _ := cmd.Flags().GetBool("markdown"); md {
+		app.RenderIssuesAsMarkdown(issues)
 	}
 
 	if a.Output == "json" {

--- a/cmd/epic/view.go
+++ b/cmd/epic/view.go
@@ -23,6 +23,7 @@ var viewCmd = &cobra.Command{
 func init() {
 	viewCmd.Flags().Bool("no-children", false, "Skip fetching child issues")
 	viewCmd.Flags().Int("max-children", 100, "Maximum children to fetch")
+	viewCmd.Flags().Bool("markdown", false, "Convert description fields from Jira Wiki Markup to Markdown")
 }
 
 func runView(cmd *cobra.Command, args []string) error {
@@ -46,6 +47,11 @@ func runView(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("fetching children: %w", err)
 		}
+	}
+
+	if md, _ := cmd.Flags().GetBool("markdown"); md {
+		app.RenderIssueAsMarkdown(issue)
+		app.RenderIssuesAsMarkdown(children)
 	}
 
 	if a.Output == "json" {

--- a/cmd/issue/comment_list.go
+++ b/cmd/issue/comment_list.go
@@ -19,6 +19,10 @@ var commentListCmd = &cobra.Command{
 	RunE:    runCommentList,
 }
 
+func init() {
+	commentListCmd.Flags().Bool("markdown", false, "Convert comment bodies from Jira Wiki Markup to Markdown")
+}
+
 func runCommentList(cmd *cobra.Command, args []string) error {
 	a := app.Get()
 	key := args[0]
@@ -26,6 +30,10 @@ func runCommentList(cmd *cobra.Command, args []string) error {
 	comments, err := a.Client.GetComments(context.Background(), key)
 	if err != nil {
 		return err
+	}
+
+	if md, _ := cmd.Flags().GetBool("markdown"); md {
+		app.RenderCommentsAsMarkdown(comments)
 	}
 
 	if a.Output == "json" {

--- a/cmd/issue/list.go
+++ b/cmd/issue/list.go
@@ -25,6 +25,7 @@ func init() {
 	listCmd.Flags().String("epic", "", "Filter by parent Epic key (issues linked to this Epic)")
 	listCmd.Flags().String("jql", "", "Raw JQL query (overrides other filters)")
 	listCmd.Flags().Int("max", 50, "Maximum number of results")
+	listCmd.Flags().Bool("markdown", false, "Convert description fields from Jira Wiki Markup to Markdown")
 }
 
 func runList(cmd *cobra.Command, args []string) error {
@@ -51,6 +52,10 @@ func runList(cmd *cobra.Command, args []string) error {
 	issues, err := app.Get().Client.SearchAllIssues(context.Background(), jql, max)
 	if err != nil {
 		return err
+	}
+
+	if md, _ := cmd.Flags().GetBool("markdown"); md {
+		app.RenderIssuesAsMarkdown(issues)
 	}
 
 	if app.Get().Output == "json" {

--- a/cmd/issue/view.go
+++ b/cmd/issue/view.go
@@ -17,11 +17,19 @@ var viewCmd = &cobra.Command{
 	RunE:    runView,
 }
 
+func init() {
+	viewCmd.Flags().Bool("markdown", false, "Convert description and comment bodies from Jira Wiki Markup to Markdown")
+}
+
 func runView(cmd *cobra.Command, args []string) error {
 	a := app.Get()
 	issue, err := a.Client.GetIssue(context.Background(), args[0])
 	if err != nil {
 		return err
+	}
+
+	if md, _ := cmd.Flags().GetBool("markdown"); md {
+		app.RenderIssueAsMarkdown(issue)
 	}
 
 	if a.Output == "json" {

--- a/cmd/issue/worklog_list.go
+++ b/cmd/issue/worklog_list.go
@@ -18,6 +18,10 @@ var worklogListCmd = &cobra.Command{
 	RunE:    runWorklogList,
 }
 
+func init() {
+	worklogListCmd.Flags().Bool("markdown", false, "Convert worklog comments from Jira Wiki Markup to Markdown")
+}
+
 func runWorklogList(cmd *cobra.Command, args []string) error {
 	a := app.Get()
 	key := args[0]
@@ -25,6 +29,10 @@ func runWorklogList(cmd *cobra.Command, args []string) error {
 	worklogs, err := a.Client.GetWorklogs(context.Background(), key)
 	if err != nil {
 		return err
+	}
+
+	if md, _ := cmd.Flags().GetBool("markdown"); md {
+		app.RenderWorklogsAsMarkdown(worklogs)
 	}
 
 	if a.Output == "json" {

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -59,6 +59,7 @@ func runMCPServe(cmd *cobra.Command, args []string) error {
 			mcp.WithString("epic", mcp.Description("Filter issues linked to this Epic key (e.g. ESA-42)")),
 			mcp.WithString("jql", mcp.Description("Raw JQL query (overrides other filters)")),
 			mcp.WithNumber("max", mcp.Description("Maximum number of results (default 50)")),
+			mcp.WithString("format", mcp.Description(formatParamDescription)),
 		),
 		listIssuesHandler(jc, a.Config.Project),
 	)
@@ -67,6 +68,7 @@ func runMCPServe(cmd *cobra.Command, args []string) error {
 		mcp.NewTool("jira_get_issue",
 			mcp.WithDescription("Get detailed information about a Jira issue"),
 			mcp.WithString("key", mcp.Required(), mcp.Description("Issue key (e.g. ESA-123)")),
+			mcp.WithString("format", mcp.Description(formatParamDescription)),
 		),
 		getIssueHandler(jc),
 	)
@@ -136,6 +138,7 @@ func runMCPServe(cmd *cobra.Command, args []string) error {
 		mcp.NewTool("jira_list_worklogs",
 			mcp.WithDescription("List worklog entries for a Jira issue"),
 			mcp.WithString("key", mcp.Required(), mcp.Description("Issue key (e.g. ESA-123)")),
+			mcp.WithString("format", mcp.Description(formatParamDescription)),
 		),
 		listWorklogsHandler(jc),
 	)
@@ -163,6 +166,7 @@ func runMCPServe(cmd *cobra.Command, args []string) error {
 		mcp.NewTool("jira_list_comments",
 			mcp.WithDescription("List comments on a Jira issue"),
 			mcp.WithString("key", mcp.Required(), mcp.Description("Issue key (e.g. ESA-123)")),
+			mcp.WithString("format", mcp.Description(formatParamDescription)),
 		),
 		listCommentsHandler(jc),
 	)
@@ -216,6 +220,7 @@ func runMCPServe(cmd *cobra.Command, args []string) error {
 			mcp.WithString("project", mcp.Description("Project key (e.g. ESA)")),
 			mcp.WithString("status", mcp.Description("Filter by status name")),
 			mcp.WithNumber("max", mcp.Description("Maximum number of results (default 50)")),
+			mcp.WithString("format", mcp.Description(formatParamDescription)),
 		),
 		listEpicsHandler(jc, a.Config.Project),
 	)
@@ -225,6 +230,7 @@ func runMCPServe(cmd *cobra.Command, args []string) error {
 			mcp.WithDescription("List issues linked to an Epic (Epic Link = KEY)"),
 			mcp.WithString("key", mcp.Required(), mcp.Description("Epic issue key (e.g. ESA-42)")),
 			mcp.WithNumber("max", mcp.Description("Maximum number of results (default 100)")),
+			mcp.WithString("format", mcp.Description(formatParamDescription)),
 		),
 		listEpicChildrenHandler(jc),
 	)
@@ -263,6 +269,7 @@ func runMCPServe(cmd *cobra.Command, args []string) error {
 			mcp.WithString("key", mcp.Required(), mcp.Description("Epic issue key (e.g. ESA-42)")),
 			mcp.WithBoolean("include_children", mcp.Description("Include linked children in the response (default true)")),
 			mcp.WithNumber("max_children", mcp.Description("Maximum children to return (default 100)")),
+			mcp.WithString("format", mcp.Description(formatParamDescription)),
 		),
 		viewEpicHandler(jc),
 	)
@@ -283,6 +290,13 @@ func maybeConvertMarkdown(text, format string) string {
 		return markup.MarkdownToWiki(text)
 	}
 	return text
+}
+
+// isMarkdownFormat reports whether the MCP `format` argument requests Markdown
+// output. Used by read tools to decide whether to convert Wiki→Markdown on
+// returned descriptions, comment bodies and worklog comments before responding.
+func isMarkdownFormat(format string) bool {
+	return strings.EqualFold(format, "markdown")
 }
 
 const formatParamDescription = `Input format for free-form text fields ("wiki" default, or "markdown" to convert from Markdown to Jira Wiki Markup before sending)`
@@ -314,6 +328,10 @@ func listIssuesHandler(jc *client.Client, defaultProject string) server.ToolHand
 			return mcp.NewToolResultError(err.Error()), nil
 		}
 
+		if isMarkdownFormat(req.GetString("format", "")) {
+			app.RenderIssuesAsMarkdown(issues)
+		}
+
 		return mcp.NewToolResultText(toJSON(issues)), nil
 	}
 }
@@ -328,6 +346,10 @@ func getIssueHandler(jc *client.Client) server.ToolHandlerFunc {
 		issue, err := jc.GetIssue(ctx, key)
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		if isMarkdownFormat(req.GetString("format", "")) {
+			app.RenderIssueAsMarkdown(issue)
 		}
 
 		return mcp.NewToolResultText(toJSON(issue)), nil
@@ -507,6 +529,9 @@ func listEpicsHandler(jc *client.Client, defaultProject string) server.ToolHandl
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
+		if isMarkdownFormat(req.GetString("format", "")) {
+			app.RenderIssuesAsMarkdown(issues)
+		}
 		return mcp.NewToolResultText(toJSON(issues)), nil
 	}
 }
@@ -524,6 +549,9 @@ func listEpicChildrenHandler(jc *client.Client) server.ToolHandlerFunc {
 		issues, err := jc.SearchAllIssues(ctx, jql, max)
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
+		}
+		if isMarkdownFormat(req.GetString("format", "")) {
+			app.RenderIssuesAsMarkdown(issues)
 		}
 		return mcp.NewToolResultText(toJSON(issues)), nil
 	}
@@ -614,6 +642,10 @@ func listWorklogsHandler(jc *client.Client) server.ToolHandlerFunc {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
 
+		if isMarkdownFormat(req.GetString("format", "")) {
+			app.RenderWorklogsAsMarkdown(worklogs)
+		}
+
 		return mcp.NewToolResultText(toJSON(worklogs)), nil
 	}
 }
@@ -668,6 +700,10 @@ func listCommentsHandler(jc *client.Client) server.ToolHandlerFunc {
 		comments, err := jc.GetComments(ctx, key)
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		if isMarkdownFormat(req.GetString("format", "")) {
+			app.RenderCommentsAsMarkdown(comments)
 		}
 
 		return mcp.NewToolResultText(toJSON(comments)), nil
@@ -914,6 +950,11 @@ func viewEpicHandler(jc *client.Client) server.ToolHandlerFunc {
 			if err != nil {
 				return mcp.NewToolResultError(fmt.Sprintf("fetching children: %s", err)), nil
 			}
+		}
+
+		if isMarkdownFormat(req.GetString("format", "")) {
+			app.RenderIssueAsMarkdown(issue)
+			app.RenderIssuesAsMarkdown(children)
 		}
 
 		out := struct {

--- a/internal/markup/markup.go
+++ b/internal/markup/markup.go
@@ -16,6 +16,7 @@ package markup
 import (
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 )
 
@@ -256,6 +257,214 @@ func splitTableRow(s string) []string {
 	t = strings.TrimPrefix(t, "|")
 	t = strings.TrimSuffix(t, "|")
 	parts := strings.Split(t, "|")
+	for i, p := range parts {
+		parts[i] = strings.TrimSpace(p)
+	}
+	return parts
+}
+
+// WikiToMarkdown converts a Jira Server 8 Wiki Markup string into Markdown.
+// Empty input returns the empty string unchanged. The conversion is
+// best-effort: elements with no clean Markdown equivalent (anchors, color
+// macros, panels, {toc}, …) are left literal in the output.
+//
+// AI agent context: this is the inverse of MarkdownToWiki. Together they let a
+// caller live in Markdown end-to-end (publish in Markdown, read back in
+// Markdown). Round-trip on the supported subset is approximately lossless.
+func WikiToMarkdown(s string) string {
+	if s == "" {
+		return ""
+	}
+
+	lines := strings.Split(s, "\n")
+	out := make([]string, 0, len(lines))
+
+	inFence := false
+	inQuote := false
+	inTable := false
+
+	for i := 0; i < len(lines); i++ {
+		line := lines[i]
+
+		if inFence {
+			if wikiCodeCloseRe.MatchString(line) {
+				inFence = false
+				out = append(out, "```")
+				continue
+			}
+			out = append(out, line)
+			continue
+		}
+		if m := wikiCodeOpenRe.FindStringSubmatch(line); m != nil {
+			inFence = true
+			out = append(out, "```"+m[1])
+			continue
+		}
+
+		if inQuote {
+			if wikiQuoteCloseRe.MatchString(line) {
+				inQuote = false
+				continue
+			}
+			out = append(out, "> "+transformInlineWiki(line))
+			continue
+		}
+		if wikiQuoteOpenRe.MatchString(line) {
+			inQuote = true
+			continue
+		}
+
+		if isWikiTableHeader(line) {
+			cells := splitWikiTableHeader(line)
+			for j, c := range cells {
+				cells[j] = transformInlineWiki(c)
+			}
+			out = append(out, "| "+strings.Join(cells, " | ")+" |")
+			seps := make([]string, len(cells))
+			for j := range seps {
+				seps[j] = "---"
+			}
+			out = append(out, "| "+strings.Join(seps, " | ")+" |")
+			inTable = true
+			continue
+		}
+		if inTable && isWikiTableRow(line) {
+			cells := splitTableRow(line)
+			for j, c := range cells {
+				cells[j] = transformInlineWiki(c)
+			}
+			out = append(out, "| "+strings.Join(cells, " | ")+" |")
+			continue
+		}
+		if inTable {
+			inTable = false
+		}
+
+		if wikiHRRe.MatchString(line) {
+			out = append(out, "---")
+			continue
+		}
+
+		if m := wikiHeadingRe.FindStringSubmatch(line); m != nil {
+			level, _ := strconv.Atoi(m[1])
+			out = append(out, strings.Repeat("#", level)+" "+transformInlineWiki(m[2]))
+			continue
+		}
+
+		if rest, ok := strings.CutPrefix(line, "bq. "); ok {
+			out = append(out, "> "+transformInlineWiki(rest))
+			continue
+		}
+		if line == "bq." {
+			out = append(out, ">")
+			continue
+		}
+
+		if m := wikiBulletListRe.FindStringSubmatch(line); m != nil {
+			depth := len(m[1])
+			indent := strings.Repeat("  ", depth-1)
+			out = append(out, indent+"- "+transformInlineWiki(m[2]))
+			continue
+		}
+		if m := wikiNumberedListRe.FindStringSubmatch(line); m != nil {
+			depth := len(m[1])
+			indent := strings.Repeat("  ", depth-1)
+			out = append(out, indent+"1. "+transformInlineWiki(m[2]))
+			continue
+		}
+
+		out = append(out, transformInlineWiki(line))
+	}
+
+	return strings.Join(out, "\n")
+}
+
+var (
+	wikiCodeOpenRe     = regexp.MustCompile(`^\{code(?::([A-Za-z0-9_+\-]*))?\}\s*$`)
+	wikiCodeCloseRe    = regexp.MustCompile(`^\{code\}\s*$`)
+	wikiQuoteOpenRe    = regexp.MustCompile(`^\{quote\}\s*$`)
+	wikiQuoteCloseRe   = regexp.MustCompile(`^\{quote\}\s*$`)
+	wikiHeadingRe      = regexp.MustCompile(`^h([1-6])\.\s+(.*)$`)
+	wikiBulletListRe   = regexp.MustCompile(`^(\*+)\s+(.*)$`)
+	wikiNumberedListRe = regexp.MustCompile(`^(#+)\s+(.*)$`)
+	wikiHRRe           = regexp.MustCompile(`^-{4,}\s*$`)
+
+	wikiInlineCodeRe = regexp.MustCompile(`\{\{([^}\n]+)\}\}`)
+	wikiBoldRe       = regexp.MustCompile(`(^|[^\w*])\*([^*\n]+)\*([^\w*]|$)`)
+	wikiItalicRe     = regexp.MustCompile(`(^|[^\w_])_([^_\n]+)_([^\w_]|$)`)
+	wikiStrikeRe     = regexp.MustCompile(`(^|[^\w-])-(\S[^-\n]*\S|\S)-([^\w-]|$)`)
+	wikiLinkRe       = regexp.MustCompile(`\[([^\]|\n]+)\|([^\]\n]+)\]`)
+	wikiImageRe      = regexp.MustCompile(`!([^!\s\n|]+)!`)
+
+	wikiCodePlaceholderRe = regexp.MustCompile(`\x00W(\d+)\x00`)
+	wikiBoldPlaceholderRe = regexp.MustCompile(`\x00X(\d+)\x00`)
+)
+
+// transformInlineWiki applies inline conversions to a single Wiki line.
+// Inline code spans are extracted to placeholders first to avoid being
+// re-processed; bold spans are also placeholdered so the italic/strike passes
+// can use simple regexes without ambiguity.
+func transformInlineWiki(s string) string {
+	if s == "" {
+		return s
+	}
+
+	var codes []string
+	s = wikiInlineCodeRe.ReplaceAllStringFunc(s, func(m string) string {
+		inner := m[2 : len(m)-2]
+		idx := len(codes)
+		codes = append(codes, inner)
+		return fmt.Sprintf("\x00W%d\x00", idx)
+	})
+
+	var bolds []string
+	s = wikiBoldRe.ReplaceAllStringFunc(s, func(m string) string {
+		sub := wikiBoldRe.FindStringSubmatch(m)
+		idx := len(bolds)
+		bolds = append(bolds, sub[2])
+		return sub[1] + fmt.Sprintf("\x00X%d\x00", idx) + sub[3]
+	})
+
+	s = wikiItalicRe.ReplaceAllString(s, "${1}*${2}*${3}")
+	s = wikiStrikeRe.ReplaceAllString(s, "${1}~~${2}~~${3}")
+	s = wikiLinkRe.ReplaceAllString(s, "[${1}](${2})")
+	s = wikiImageRe.ReplaceAllString(s, "![${1}](${1})")
+
+	s = wikiBoldPlaceholderRe.ReplaceAllStringFunc(s, func(m string) string {
+		var idx int
+		fmt.Sscanf(m, "\x00X%d\x00", &idx)
+		return "**" + bolds[idx] + "**"
+	})
+	s = wikiCodePlaceholderRe.ReplaceAllStringFunc(s, func(m string) string {
+		var idx int
+		fmt.Sscanf(m, "\x00W%d\x00", &idx)
+		return "`" + codes[idx] + "`"
+	})
+
+	return s
+}
+
+func isWikiTableHeader(s string) bool {
+	t := strings.TrimSpace(s)
+	return strings.HasPrefix(t, "||") && strings.HasSuffix(t, "||") && len(t) >= 4
+}
+
+func isWikiTableRow(s string) bool {
+	t := strings.TrimSpace(s)
+	if len(t) < 2 {
+		return false
+	}
+	if strings.HasPrefix(t, "||") {
+		return false
+	}
+	return strings.HasPrefix(t, "|") && strings.HasSuffix(t, "|")
+}
+
+func splitWikiTableHeader(s string) []string {
+	t := strings.TrimSpace(s)
+	t = strings.TrimPrefix(t, "||")
+	t = strings.TrimSuffix(t, "||")
+	parts := strings.Split(t, "||")
 	for i, p := range parts {
 		parts[i] = strings.TrimSpace(p)
 	}

--- a/internal/markup/markup_test.go
+++ b/internal/markup/markup_test.go
@@ -117,3 +117,145 @@ func TestMarkdownToWiki(t *testing.T) {
 		})
 	}
 }
+
+func TestWikiToMarkdown(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"plain", "just text", "just text"},
+
+		{"h1", "h1. Title", "# Title"},
+		{"h3", "h3. Section", "### Section"},
+		{"h6", "h6. Tiny", "###### Tiny"},
+
+		{"bold", "this is *bold* here", "this is **bold** here"},
+		{"italic", "this is _italic_ here", "this is *italic* here"},
+		{"strike", "this is -gone- here", "this is ~~gone~~ here"},
+		{"inline code", "use {{make build}}", "use `make build`"},
+		{"link", "see [docs|https://example.com]", "see [docs](https://example.com)"},
+		{"image", "!screenshot.png!", "![screenshot.png](screenshot.png)"},
+
+		{"bold then italic", "*bold* and _italic_", "**bold** and *italic*"},
+
+		{
+			"underscore inside identifier is not italic",
+			"call my_helper_func",
+			"call my_helper_func",
+		},
+		{
+			"hyphens in dates are not strike",
+			"on 2026-04-30 we shipped",
+			"on 2026-04-30 we shipped",
+		},
+
+		{
+			"fenced code preserves content",
+			"before\n{code:go}\nfunc f() {}\n{code}\nafter",
+			"before\n```go\nfunc f() {}\n```\nafter",
+		},
+		{
+			"fenced code without lang",
+			"{code}\nplain text\n{code}",
+			"```\nplain text\n```",
+		},
+		{
+			"wiki markers inside fence are NOT transformed",
+			"{code}\n*not bold*\nh1. not heading\n{code}",
+			"```\n*not bold*\nh1. not heading\n```",
+		},
+
+		{
+			"unordered list",
+			"* one\n* two\n* three",
+			"- one\n- two\n- three",
+		},
+		{
+			"nested unordered list",
+			"* one\n** one.a\n** one.b\n* two",
+			"- one\n  - one.a\n  - one.b\n- two",
+		},
+		{
+			"ordered list",
+			"# first\n# second\n# third",
+			"1. first\n1. second\n1. third",
+		},
+
+		{
+			"blockquote single line",
+			"bq. quoted text",
+			"> quoted text",
+		},
+		{
+			"blockquote with wiki inline",
+			"bq. *important* note",
+			"> **important** note",
+		},
+		{
+			"quote block",
+			"{quote}\nfirst line\nsecond line\n{quote}",
+			"> first line\n> second line",
+		},
+
+		{
+			"horizontal rule",
+			"above\n\n----\n\nbelow",
+			"above\n\n---\n\nbelow",
+		},
+
+		{
+			"table basic",
+			"||Name||Role||\n|Alice|dev|\n|Bob|ops|",
+			"| Name | Role |\n| --- | --- |\n| Alice | dev |\n| Bob | ops |",
+		},
+		{
+			"table with inline formatting",
+			"||Field||Value||\n|{{id}}|*42*|",
+			"| Field | Value |\n| --- | --- |\n| `id` | **42** |",
+		},
+
+		{
+			"complex mixed document",
+			"h1. Plan\n\nWe need to ship *soon*.\n\n* spec the {{API}}\n* write tests\n\n{code:go}\nfunc main() {}\n{code}\n\nSee [tracker|https://example.com].",
+			"# Plan\n\nWe need to ship **soon**.\n\n- spec the `API`\n- write tests\n\n```go\nfunc main() {}\n```\n\nSee [tracker](https://example.com).",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := WikiToMarkdown(tc.in)
+			if got != tc.want {
+				t.Errorf("WikiToMarkdown(%q)\n  got  %q\n  want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRoundTrip checks the lossless subset: Markdown → Wiki → Markdown should
+// produce text equivalent to the original. The full superset of Markdown is
+// not lossless (e.g. * vs - for unordered bullets, _italic_ vs *italic*), so
+// the test inputs are deliberately written in the "canonical" form that the
+// converters target.
+func TestRoundTrip(t *testing.T) {
+	canonical := []string{
+		"# Title\n\nA paragraph with **bold**, *italic*, ~~strike~~, and `code`.",
+		"- one\n- two\n  - nested\n- three",
+		"```go\nfunc f() {}\n```",
+		"> quoted line",
+		"| h1 | h2 |\n| --- | --- |\n| c1 | c2 |",
+		"See [the link](https://example.com).",
+		"---",
+	}
+
+	for _, original := range canonical {
+		t.Run(original[:min(len(original), 30)], func(t *testing.T) {
+			wiki := MarkdownToWiki(original)
+			back := WikiToMarkdown(wiki)
+			if back != original {
+				t.Errorf("round trip differs:\n  original %q\n  via wiki %q\n  got back %q", original, wiki, back)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- New `WikiToMarkdown` function in `internal/markup` that mirrors the existing `MarkdownToWiki` (headings, bold/italic/strike, inline code, fenced code, lists nested, blockquotes, quote blocks, HR, tables, links, images).
- CLI: `--markdown` added to `issue view`, `issue list`, `issue comment-list`, `issue worklog-list`, `epic view`, `epic list`, `epic children`.
- MCP: `format` parameter (`"wiki"` default, `"markdown"` to convert) added to `jira_get_issue`, `jira_list_issues`, `jira_list_comments`, `jira_list_worklogs`, `jira_view_epic`, `jira_list_epics`, `jira_list_epic_children`.
- New helper package `cmd/app/render.go` with `RenderIssueAsMarkdown` / `RenderIssuesAsMarkdown` / `RenderCommentsAsMarkdown` / `RenderWorklogsAsMarkdown`. Reused from both `cmd/issue` and `cmd/epic` packages.

Closes #48.

## Why this is non-trivial
`models.IssueFields.MarshalJSON` re-emits the raw Jira payload so custom fields (e.g. Epic Name) survive serialization. Mutating the typed `Description` was therefore invisible in JSON output. The render helper syncs the typed fields back into `Raw` after conversion so JSON callers see the converted output too.

## Round-trip semantics
Together with #19 / #47, `--markdown` is a single direction-aware flag:
- write commands (`create`, `edit`, `comment-add`, `comment-edit`, `worklog-add`): convert Markdown → Wiki before sending.
- read commands (this PR): convert Wiki → Markdown after receiving.

A `TestRoundTrip` in `markup_test.go` checks that `WikiToMarkdown(MarkdownToWiki(x))` equals `x` on the lossless subset.

## Test plan
- [x] `go vet ./...` clean.
- [x] `go test ./...` green (33 markup cases + round-trip property).
- [x] Manual smoke against the Amplía Jira (TEST-6):
  - `issue view --markdown` (text and JSON) — description and embedded comment converted.
  - `issue comment-list --markdown` — comment body in Markdown.
  - `issue worklog-list --markdown` — worklog comment in Markdown.
  - `issue list --markdown` and `epic list --markdown` — text mode unaffected (description not shown), JSON mode converts.
- [ ] Manual MCP smoke (deferred — not blocking).

## Out of scope
- Lossy elements (`{anchor:...}`, `{color:...}`, panel/note macros, `{toc}`, `{include:...}`) are left literal; documented in the issue.
- Pretty terminal rendering of the Markdown output (deferred decision in #21).
- Edge case: `\`{code}\`` (literal `{code}` text inside Markdown inline code) currently round-trips as `\`{code\`}` — known cosmetic issue with the placeholder mechanism, unlikely to bite real content.