### PR TITLE
feat: --description-file / --body-file / --comment-file with stdin support

### DIFF
--- a/cmd/app/input.go
+++ b/cmd/app/input.go
@@ -1,0 +1,66 @@
+package app
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// ReadTextInput resolves a pair of flags: an inline string flag (e.g.
+// "description") and a corresponding "<flag>-file" flag (e.g.
+// "description-file"). The file flag accepts "-" to mean stdin, enabling
+// pipelines like `cat foo.md | jira8 issue create --description-file -`.
+//
+// Returns the resolved text, plus a boolean indicating whether the user set
+// either flag (useful for edit subcommands that only update fields the user
+// actually touched). Errors when both flags are set, or when the file cannot
+// be read.
+//
+// AI agent context: this helper exists because pasting long Markdown / Wiki
+// payloads inline forces ugly bash escaping for backticks, dollars, quotes
+// and embedded JSON. File / stdin input sidesteps the shell entirely.
+func ReadTextInput(cmd *cobra.Command, inlineFlag, fileFlag string) (text string, set bool, err error) {
+	inlineSet := cmd.Flags().Changed(inlineFlag)
+	fileSet := cmd.Flags().Changed(fileFlag)
+
+	if inlineSet && fileSet {
+		return "", true, fmt.Errorf("--%s and --%s are mutually exclusive", inlineFlag, fileFlag)
+	}
+
+	if fileSet {
+		path, _ := cmd.Flags().GetString(fileFlag)
+		data, err := readFromPathOrStdin(path)
+		if err != nil {
+			return "", true, err
+		}
+		return string(data), true, nil
+	}
+
+	if inlineSet {
+		v, _ := cmd.Flags().GetString(inlineFlag)
+		return v, true, nil
+	}
+
+	v, _ := cmd.Flags().GetString(inlineFlag)
+	return v, false, nil
+}
+
+// stdinReader is overridable so tests can feed synthetic input.
+var stdinReader io.Reader = os.Stdin
+
+func readFromPathOrStdin(path string) ([]byte, error) {
+	if path == "-" {
+		data, err := io.ReadAll(stdinReader)
+		if err != nil {
+			return nil, fmt.Errorf("reading stdin: %w", err)
+		}
+		return data, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+	return data, nil
+}

--- a/cmd/app/input_test.go
+++ b/cmd/app/input_test.go
@@ -1,0 +1,128 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func newTestCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("description", "", "")
+	cmd.Flags().String("description-file", "", "")
+	return cmd
+}
+
+func TestReadTextInput_InlineOnly(t *testing.T) {
+	cmd := newTestCmd()
+	if err := cmd.ParseFlags([]string{"--description", "hello"}); err != nil {
+		t.Fatal(err)
+	}
+	got, set, err := ReadTextInput(cmd, "description", "description-file")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !set || got != "hello" {
+		t.Errorf("got (%q, %v), want (%q, true)", got, set, "hello")
+	}
+}
+
+func TestReadTextInput_FileOnly(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "body.md")
+	content := "# heading\n\nbody with `code` and **bold**"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newTestCmd()
+	if err := cmd.ParseFlags([]string{"--description-file", path}); err != nil {
+		t.Fatal(err)
+	}
+	got, set, err := ReadTextInput(cmd, "description", "description-file")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !set || got != content {
+		t.Errorf("got (%q, %v), want (%q, true)", got, set, content)
+	}
+}
+
+func TestReadTextInput_Conflict(t *testing.T) {
+	cmd := newTestCmd()
+	if err := cmd.ParseFlags([]string{"--description", "x", "--description-file", "/tmp/y"}); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err := ReadTextInput(cmd, "description", "description-file")
+	if err == nil {
+		t.Fatal("expected conflict error, got nil")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("error %q does not mention mutual exclusion", err)
+	}
+}
+
+func TestReadTextInput_FileMissing(t *testing.T) {
+	cmd := newTestCmd()
+	if err := cmd.ParseFlags([]string{"--description-file", "/nonexistent/path.md"}); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err := ReadTextInput(cmd, "description", "description-file")
+	if err == nil {
+		t.Fatal("expected file-not-found error, got nil")
+	}
+}
+
+func TestReadTextInput_NeitherSet(t *testing.T) {
+	cmd := newTestCmd()
+	if err := cmd.ParseFlags([]string{}); err != nil {
+		t.Fatal(err)
+	}
+	got, set, err := ReadTextInput(cmd, "description", "description-file")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if set || got != "" {
+		t.Errorf("got (%q, %v), want (\"\", false)", got, set)
+	}
+}
+
+func TestReadTextInput_Stdin(t *testing.T) {
+	cmd := newTestCmd()
+	if err := cmd.ParseFlags([]string{"--description-file", "-"}); err != nil {
+		t.Fatal(err)
+	}
+	prev := stdinReader
+	stdinReader = strings.NewReader("piped content")
+	defer func() { stdinReader = prev }()
+
+	got, set, err := ReadTextInput(cmd, "description", "description-file")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !set || got != "piped content" {
+		t.Errorf("got (%q, %v), want (%q, true)", got, set, "piped content")
+	}
+}
+
+func TestReadTextInput_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty.md")
+	if err := os.WriteFile(path, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := newTestCmd()
+	if err := cmd.ParseFlags([]string{"--description-file", path}); err != nil {
+		t.Fatal(err)
+	}
+	got, set, err := ReadTextInput(cmd, "description", "description-file")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !set || got != "" {
+		t.Errorf("got (%q, %v), want (\"\", true)", got, set)
+	}
+}

--- a/cmd/epic/create.go
+++ b/cmd/epic/create.go
@@ -24,6 +24,7 @@ func init() {
 	createCmd.Flags().String("summary", "", "Epic summary (required)")
 	createCmd.Flags().String("project", "", "Project key (default from config)")
 	createCmd.Flags().String("description", "", "Epic description")
+	createCmd.Flags().String("description-file", "", "Read description from file (use - for stdin)")
 	createCmd.Flags().String("assignee", "", "Assignee username (use 'me' for current user)")
 	createCmd.Flags().String("priority", "", "Priority name")
 	createCmd.Flags().Bool("markdown", false, "Treat --description as Markdown and convert to Jira Wiki Markup before sending")
@@ -41,7 +42,10 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	if project == "" {
 		project = a.Config.Project
 	}
-	description, _ := cmd.Flags().GetString("description")
+	description, _, err := app.ReadTextInput(cmd, "description", "description-file")
+	if err != nil {
+		return err
+	}
 	if md, _ := cmd.Flags().GetBool("markdown"); md {
 		description = markup.MarkdownToWiki(description)
 	}

--- a/cmd/epic/edit.go
+++ b/cmd/epic/edit.go
@@ -23,6 +23,7 @@ func init() {
 	editCmd.Flags().String("name", "", "New Epic Name")
 	editCmd.Flags().String("summary", "", "New summary")
 	editCmd.Flags().String("description", "", "New description")
+	editCmd.Flags().String("description-file", "", "Read new description from file (use - for stdin)")
 	editCmd.Flags().String("assignee", "", "New assignee (use 'me' for current user, empty to unassign)")
 	editCmd.Flags().String("priority", "", "New priority")
 	editCmd.Flags().Bool("markdown", false, "Treat --description as Markdown and convert to Jira Wiki Markup before sending")
@@ -47,8 +48,9 @@ func runEdit(cmd *cobra.Command, args []string) error {
 		v, _ := cmd.Flags().GetString("summary")
 		fields["summary"] = v
 	}
-	if cmd.Flags().Changed("description") {
-		v, _ := cmd.Flags().GetString("description")
+	if v, set, err := app.ReadTextInput(cmd, "description", "description-file"); err != nil {
+		return err
+	} else if set {
 		if md, _ := cmd.Flags().GetBool("markdown"); md {
 			v = markup.MarkdownToWiki(v)
 		}

--- a/cmd/issue/comment_add.go
+++ b/cmd/issue/comment_add.go
@@ -21,16 +21,22 @@ var commentAddCmd = &cobra.Command{
 }
 
 func init() {
-	commentAddCmd.Flags().String("body", "", "Comment body (required)")
+	commentAddCmd.Flags().String("body", "", "Comment body (required, or use --body-file)")
+	commentAddCmd.Flags().String("body-file", "", "Read body from file (use - for stdin)")
 	commentAddCmd.Flags().Bool("markdown", false, "Treat --body as Markdown and convert to Jira Wiki Markup before sending")
-	_ = commentAddCmd.MarkFlagRequired("body")
 }
 
 func runCommentAdd(cmd *cobra.Command, args []string) error {
 	a := app.Get()
 	key := args[0]
 
-	body, _ := cmd.Flags().GetString("body")
+	body, set, err := app.ReadTextInput(cmd, "body", "body-file")
+	if err != nil {
+		return err
+	}
+	if !set || body == "" {
+		return fmt.Errorf("comment body is required (use --body or --body-file)")
+	}
 	if md, _ := cmd.Flags().GetBool("markdown"); md {
 		body = markup.MarkdownToWiki(body)
 	}

--- a/cmd/issue/comment_edit.go
+++ b/cmd/issue/comment_edit.go
@@ -21,10 +21,10 @@ var commentEditCmd = &cobra.Command{
 
 func init() {
 	commentEditCmd.Flags().String("id", "", "Comment ID (required)")
-	commentEditCmd.Flags().String("body", "", "Updated comment body (required)")
+	commentEditCmd.Flags().String("body", "", "Updated comment body (required, or use --body-file)")
+	commentEditCmd.Flags().String("body-file", "", "Read updated body from file (use - for stdin)")
 	commentEditCmd.Flags().Bool("markdown", false, "Treat --body as Markdown and convert to Jira Wiki Markup before sending")
 	_ = commentEditCmd.MarkFlagRequired("id")
-	_ = commentEditCmd.MarkFlagRequired("body")
 }
 
 func runCommentEdit(cmd *cobra.Command, args []string) error {
@@ -32,7 +32,13 @@ func runCommentEdit(cmd *cobra.Command, args []string) error {
 	key := args[0]
 
 	commentID, _ := cmd.Flags().GetString("id")
-	body, _ := cmd.Flags().GetString("body")
+	body, set, err := app.ReadTextInput(cmd, "body", "body-file")
+	if err != nil {
+		return err
+	}
+	if !set || body == "" {
+		return fmt.Errorf("comment body is required (use --body or --body-file)")
+	}
 	if md, _ := cmd.Flags().GetBool("markdown"); md {
 		body = markup.MarkdownToWiki(body)
 	}

--- a/cmd/issue/create.go
+++ b/cmd/issue/create.go
@@ -24,6 +24,7 @@ func init() {
 	createCmd.Flags().String("type", "Task", "Issue type")
 	createCmd.Flags().String("project", "", "Project key (default from config)")
 	createCmd.Flags().String("description", "", "Issue description")
+	createCmd.Flags().String("description-file", "", "Read description from file (use - for stdin)")
 	createCmd.Flags().String("assignee", "", "Assignee username (use 'me' for current user)")
 	createCmd.Flags().String("priority", "", "Issue priority")
 	createCmd.Flags().String("parent", "", "Parent issue key for Sub-task creation (e.g. ESA-65)")
@@ -43,7 +44,10 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	if project == "" {
 		project = a.Config.Project
 	}
-	description, _ := cmd.Flags().GetString("description")
+	description, _, err := app.ReadTextInput(cmd, "description", "description-file")
+	if err != nil {
+		return err
+	}
 	if md, _ := cmd.Flags().GetBool("markdown"); md {
 		description = markup.MarkdownToWiki(description)
 	}

--- a/cmd/issue/edit.go
+++ b/cmd/issue/edit.go
@@ -22,6 +22,7 @@ var editCmd = &cobra.Command{
 func init() {
 	editCmd.Flags().String("summary", "", "New summary")
 	editCmd.Flags().String("description", "", "New description")
+	editCmd.Flags().String("description-file", "", "Read new description from file (use - for stdin)")
 	editCmd.Flags().String("assignee", "", "New assignee (use 'me' for current user, empty to unassign)")
 	editCmd.Flags().String("priority", "", "New priority")
 	editCmd.Flags().String("epic-name", "", "New Epic Name (only valid on Epic issues)")
@@ -40,8 +41,9 @@ func runEdit(cmd *cobra.Command, args []string) error {
 		fields["summary"] = v
 	}
 
-	if cmd.Flags().Changed("description") {
-		v, _ := cmd.Flags().GetString("description")
+	if v, set, err := app.ReadTextInput(cmd, "description", "description-file"); err != nil {
+		return err
+	} else if set {
 		if md, _ := cmd.Flags().GetBool("markdown"); md {
 			v = markup.MarkdownToWiki(v)
 		}

--- a/cmd/issue/worklog_add.go
+++ b/cmd/issue/worklog_add.go
@@ -25,6 +25,7 @@ func init() {
 	worklogAddCmd.Flags().String("time", "", "Time spent (e.g., 2h, 30m, 1d) (required)")
 	worklogAddCmd.Flags().String("date", "", "Start date/time in ISO 8601 (optional, defaults to now)")
 	worklogAddCmd.Flags().String("comment", "", "Worklog comment (optional)")
+	worklogAddCmd.Flags().String("comment-file", "", "Read worklog comment from file (use - for stdin)")
 	worklogAddCmd.Flags().Bool("markdown", false, "Treat --comment as Markdown and convert to Jira Wiki Markup before sending")
 	_ = worklogAddCmd.MarkFlagRequired("time")
 }
@@ -35,7 +36,10 @@ func runWorklogAdd(cmd *cobra.Command, args []string) error {
 
 	timeSpent, _ := cmd.Flags().GetString("time")
 	started, _ := cmd.Flags().GetString("date")
-	comment, _ := cmd.Flags().GetString("comment")
+	comment, _, err := app.ReadTextInput(cmd, "comment", "comment-file")
+	if err != nil {
+		return err
+	}
 	if md, _ := cmd.Flags().GetBool("markdown"); md && comment != "" {
 		comment = markup.MarkdownToWiki(comment)
 	}


### PR DESCRIPTION
## Summary
- New flags on the seven long-text commands:
  - \`issue create\`, \`issue edit\`, \`epic create\`, \`epic edit\`: \`--description-file\`
  - \`issue comment-add\`, \`issue comment-edit\`: \`--body-file\`
  - \`issue worklog-add\`: \`--comment-file\`
- Path \`-\` means stdin, enabling pipelines:
  - \`pandoc spec.md -t markdown | jira8 issue create --description-file - --markdown\`
  - \`cat snippet.md | jira8 issue comment-add CO-336 --body-file - --markdown\`
- Mutually exclusive with the corresponding inline flag (\`--description\`, \`--body\`, \`--comment\`); passing both yields a clear error.
- Combinable with \`--markdown\` from #19 — file content runs through the converter before sending.

Closes #20.

## Why this matters
Inline string flags die on long Markdown / Wiki payloads with backticks, dollars, quotes and embedded JSON because of bash escaping. File / stdin input sidesteps the shell entirely. This was the largest day-to-day pain identified in the \`jira8-improvements.md\` review.

## MCP scope
No MCP changes. The MCP tools already accept the field as a string parameter; file paths don't make sense over stdio. Functional parity is unchanged.

## Implementation
- New \`cmd/app/input.go\` with \`ReadTextInput(cmd, inlineFlag, fileFlag) (text, set, err)\`. The \`set\` boolean lets edit subcommands distinguish \"not touched\" from \"set to empty\".
- \`stdinReader\` var is overridable in tests so the helper is fully unit-tested without OS plumbing.
- Edit subcommands now check the helper's \`set\` return instead of \`cmd.Flags().Changed(\"description\")\`, so either flag triggers the update.

## Test plan
- [x] \`go vet ./...\` clean.
- [x] \`go test ./...\` green (7 new unit cases for the helper: inline only, file only, conflict, missing file, neither set, stdin, empty file).
- [x] Smoke test against TEST-7:
  - \`issue create --description-file <evil.md> --markdown\` with backticks, \$vars, quotes, JSON embedded — sent and rendered correctly.
  - \`comment-add --body-file -\` via \`printf | jira8\` pipeline — round-trip OK.
  - Conflict (\`--description\` + \`--description-file\`) returns the expected error.
  - Missing file path returns a clear error.