### PR TITLE
feat: add issue attachment add/list/delete + --attach flags (CLI + MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,25 @@ jira8 issue worklog-add MYPROJ-123 --time 2h --comment "Investig."   # add a wor
 jira8 issue worklog-add MYPROJ-123 --time 30m --date 2026-04-15T09:00:00.000+0200
 ```
 
+### Attachments
+
+```bash
+jira8 issue attachment add MYPROJ-123 diag.png trace.log       # upload one or more files
+jira8 issue attachment list MYPROJ-123                         # list attachments
+jira8 issue attachment delete 45821                            # delete by attachment ID
+
+# Or attach at create/edit time:
+jira8 issue create --summary "Crash on login" --type Bug \
+    --attach screenshot.png --attach trace.log
+jira8 issue edit MYPROJ-123 --attach extra-evidence.pdf        # adjuntar sin tocar otros campos
+```
+
+Uploads stream from disk so large files do not get buffered in memory. The
+upload step is separate from create/edit (Jira's `/issue` endpoint does not
+accept files) and is not transactional: if the issue is created but the upload
+fails, you get back the new key and the upload error so you can retry with
+`issue attachment add`.
+
 ### Project metadata
 
 Query valid values for issue types, statuses, and priorities:
@@ -198,8 +217,8 @@ jira8 mcp serve
 |------|-------------|
 | `jira_list_issues` | List issues (supports `type`, `epic`, JQL, etc.) |
 | `jira_get_issue` | Get issue details |
-| `jira_create_issue` | Create a new issue (supports `epic_name`, `epic_link`) |
-| `jira_edit_issue` | Edit an existing issue (supports `epic_name`, `epic_link`) |
+| `jira_create_issue` | Create a new issue (supports `epic_name`, `epic_link`, `attachments[]`) |
+| `jira_edit_issue` | Edit an existing issue (supports `epic_name`, `epic_link`, `attachments[]`) |
 | `jira_transition_issue` | Transition an issue |
 | `jira_list_transitions` | List available transitions |
 | `jira_add_comment` | Add a comment |
@@ -209,6 +228,9 @@ jira8 mcp serve
 | `jira_add_worklog` | Add a worklog entry |
 | `jira_list_worklogs` | List worklog entries |
 | `jira_delete_worklog` | Delete a worklog entry |
+| `jira_add_attachment` | Upload one or more files to an issue |
+| `jira_list_attachments` | List attachments on an issue |
+| `jira_delete_attachment` | Delete an attachment by ID |
 | `jira_list_issue_types` | List issue types for a project |
 | `jira_list_statuses` | List statuses grouped by issue type |
 | `jira_list_priorities` | List available priorities |
@@ -217,6 +239,15 @@ jira8 mcp serve
 | `jira_create_epic` | Create an Epic (shortcut for `jira_create_issue` with `type=Epic`) |
 | `jira_edit_epic` | Edit an Epic (exposes friendly `name` for Epic Name) |
 | `jira_view_epic` | Get an Epic and (optionally) its linked children in one call |
+
+> **Attachment paths and MCP security.** `jira_add_attachment`, and the
+> `attachments[]` parameters on `jira_create_issue` / `jira_edit_issue`, read
+> files from the filesystem of the host running `jira8 mcp serve` — **not** the
+> agent's client machine. When jira8 runs on the same host as the user (typical
+> Claude Desktop / Claude Code setup) this is transparent. When jira8 runs on a
+> shared or remote host, it widens the blast radius: an agent that can call
+> these tools can upload any file the jira8 process can read. Treat the MCP
+> server's file access as part of the trust boundary.
 
 ### Available MCP resources
 

--- a/cmd/issue/attachment.go
+++ b/cmd/issue/attachment.go
@@ -1,0 +1,130 @@
+package issue
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/amplia/jira8/cmd/app"
+	"github.com/spf13/cobra"
+)
+
+// attachmentCmd is the parent for attachment subcommands.
+// Mirrors the Jira REST surface: upload (POST), list (GET issue), delete (DELETE by id).
+// The matching MCP tools are jira_add_attachment, jira_list_attachments,
+// jira_delete_attachment — same shape, same arguments.
+var attachmentCmd = &cobra.Command{
+	Use:     "attachment",
+	Aliases: []string{"att"},
+	Short:   "Manage issue attachments",
+}
+
+var attachmentAddCmd = &cobra.Command{
+	Use:     "add ISSUE-KEY FILE [FILE...]",
+	Short:   "Upload one or more files to an issue",
+	Example: "  jira8 issue attachment add ESA-123 diag.png trace.log",
+	Args:    cobra.MinimumNArgs(2),
+	RunE:    runAttachmentAdd,
+}
+
+var attachmentListCmd = &cobra.Command{
+	Use:     "list ISSUE-KEY",
+	Aliases: []string{"ls"},
+	Short:   "List attachments on an issue",
+	Example: "  jira8 issue attachment list ESA-123",
+	Args:    cobra.ExactArgs(1),
+	RunE:    runAttachmentList,
+}
+
+var attachmentDeleteCmd = &cobra.Command{
+	Use:     "delete ATTACHMENT-ID",
+	Aliases: []string{"rm"},
+	Short:   "Delete an attachment by ID",
+	Example: "  jira8 issue attachment delete 45821",
+	Args:    cobra.ExactArgs(1),
+	RunE:    runAttachmentDelete,
+}
+
+func init() {
+	attachmentCmd.AddCommand(attachmentAddCmd)
+	attachmentCmd.AddCommand(attachmentListCmd)
+	attachmentCmd.AddCommand(attachmentDeleteCmd)
+}
+
+func runAttachmentAdd(cmd *cobra.Command, args []string) error {
+	a := app.Get()
+	key := args[0]
+	files := args[1:]
+
+	attachments, err := a.Client.AddAttachments(context.Background(), key, files)
+	if err != nil {
+		return err
+	}
+
+	if a.Output == "json" {
+		data, err := json.MarshalIndent(attachments, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(data))
+		return nil
+	}
+
+	fmt.Printf("Uploaded %d attachment(s) to %s:\n", len(attachments), key)
+	for _, att := range attachments {
+		fmt.Printf("  %s  %s  (%s)\n", labelStyle.Render("#"+att.ID), att.Filename, humanSize(att.Size))
+	}
+	return nil
+}
+
+func runAttachmentList(cmd *cobra.Command, args []string) error {
+	a := app.Get()
+	key := args[0]
+
+	attachments, err := a.Client.ListAttachments(context.Background(), key)
+	if err != nil {
+		return err
+	}
+
+	if a.Output == "json" {
+		data, err := json.MarshalIndent(attachments, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(data))
+		return nil
+	}
+
+	if len(attachments) == 0 {
+		fmt.Printf("No attachments on %s\n", key)
+		return nil
+	}
+
+	fmt.Printf("Attachments on %s (%d):\n", key, len(attachments))
+	for _, att := range attachments {
+		created := att.Created
+		if len(created) > 10 {
+			created = created[:10]
+		}
+		fmt.Printf("  %s  %s  %s  %s  %s\n",
+			labelStyle.Render("#"+att.ID),
+			att.Filename,
+			labelStyle.Render(humanSize(att.Size)),
+			userName(att.Author),
+			labelStyle.Render(created),
+		)
+	}
+	return nil
+}
+
+func runAttachmentDelete(cmd *cobra.Command, args []string) error {
+	a := app.Get()
+	id := args[0]
+
+	if err := a.Client.DeleteAttachment(context.Background(), id); err != nil {
+		return err
+	}
+
+	fmt.Printf("Deleted attachment %s\n", id)
+	return nil
+}

--- a/cmd/issue/create.go
+++ b/cmd/issue/create.go
@@ -31,6 +31,7 @@ func init() {
 	createCmd.Flags().String("epic-name", "", "Epic Name (required when --type Epic)")
 	createCmd.Flags().String("epic-link", "", "Epic key to associate this issue with (e.g. ESA-42)")
 	createCmd.Flags().Bool("markdown", false, "Treat --description as Markdown and convert to Jira Wiki Markup before sending")
+	createCmd.Flags().StringArray("attach", nil, "Attach a file (repeatable, e.g. --attach a.png --attach b.log)")
 
 	_ = createCmd.MarkFlagRequired("summary")
 }
@@ -113,8 +114,25 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Attachments are uploaded after creation because Jira's /issue endpoint
+	// does not accept multipart bodies. The two calls are not transactional:
+	// if the upload fails the issue already exists, so we report both the
+	// created key and the upload error.
+	attachFiles, _ := cmd.Flags().GetStringArray("attach")
+	var uploaded []models.Attachment
+	if len(attachFiles) > 0 {
+		uploaded, err = a.Client.AddAttachments(context.Background(), resp.Key, attachFiles)
+		if err != nil {
+			return fmt.Errorf("created %s but failed to upload attachments: %w", resp.Key, err)
+		}
+	}
+
 	if a.Output == "json" {
-		data, err := json.MarshalIndent(resp, "", "  ")
+		payload := struct {
+			*models.CreateIssueResponse
+			Attachments []models.Attachment `json:"attachments,omitempty"`
+		}{CreateIssueResponse: resp, Attachments: uploaded}
+		data, err := json.MarshalIndent(payload, "", "  ")
 		if err != nil {
 			return err
 		}
@@ -123,5 +141,11 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Printf("Created %s\n", resp.Key)
+	if len(uploaded) > 0 {
+		fmt.Printf("Uploaded %d attachment(s):\n", len(uploaded))
+		for _, att := range uploaded {
+			fmt.Printf("  %s  %s  (%s)\n", labelStyle.Render("#"+att.ID), att.Filename, humanSize(att.Size))
+		}
+	}
 	return nil
 }

--- a/cmd/issue/edit.go
+++ b/cmd/issue/edit.go
@@ -28,6 +28,7 @@ func init() {
 	editCmd.Flags().String("epic-name", "", "New Epic Name (only valid on Epic issues)")
 	editCmd.Flags().String("epic-link", "", "Epic key to associate this issue with (empty to detach)")
 	editCmd.Flags().Bool("markdown", false, "Treat --description as Markdown and convert to Jira Wiki Markup before sending")
+	editCmd.Flags().StringArray("attach", nil, "Attach a file to the issue (repeatable). Can be used alone, without other field edits.")
 }
 
 func runEdit(cmd *cobra.Command, args []string) error {
@@ -91,15 +92,30 @@ func runEdit(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if len(fields) == 0 {
-		return fmt.Errorf("no fields to update; use --summary, --description, --assignee, --priority, --epic-name, or --epic-link")
+	attachFiles, _ := cmd.Flags().GetStringArray("attach")
+
+	if len(fields) == 0 && len(attachFiles) == 0 {
+		return fmt.Errorf("no fields to update; use --summary, --description, --assignee, --priority, --epic-name, --epic-link, or --attach")
 	}
 
-	req := &models.EditIssueRequest{Fields: fields}
-	if err := a.Client.EditIssue(context.Background(), key, req); err != nil {
-		return err
+	if len(fields) > 0 {
+		req := &models.EditIssueRequest{Fields: fields}
+		if err := a.Client.EditIssue(context.Background(), key, req); err != nil {
+			return err
+		}
+		fmt.Printf("Updated %s\n", key)
 	}
 
-	fmt.Printf("Updated %s\n", key)
+	if len(attachFiles) > 0 {
+		uploaded, err := a.Client.AddAttachments(context.Background(), key, attachFiles)
+		if err != nil {
+			return fmt.Errorf("attaching files to %s: %w", key, err)
+		}
+		fmt.Printf("Uploaded %d attachment(s) to %s:\n", len(uploaded), key)
+		for _, att := range uploaded {
+			fmt.Printf("  %s  %s  (%s)\n", labelStyle.Render("#"+att.ID), att.Filename, humanSize(att.Size))
+		}
+	}
+
 	return nil
 }

--- a/cmd/issue/format.go
+++ b/cmd/issue/format.go
@@ -185,6 +185,18 @@ func printIssueDetailWithEpic(issue *models.Issue, epicNameID, epicLinkID string
 		fmt.Println(f.Description)
 	}
 
+	if len(f.Attachment) > 0 {
+		fmt.Println()
+		fmt.Printf(labelStyle.Render("Attachments (%d):")+"\n", len(f.Attachment))
+		for _, att := range f.Attachment {
+			fmt.Printf("  %s  %s  %s\n",
+				labelStyle.Render("#"+att.ID),
+				att.Filename,
+				labelStyle.Render(humanSize(att.Size)),
+			)
+		}
+	}
+
 	if f.Comment != nil && len(f.Comment.Comments) > 0 {
 		fmt.Println()
 		fmt.Printf(labelStyle.Render("Comments (%d):")+"\n", f.Comment.Total)
@@ -204,6 +216,20 @@ func printIssueDetailWithEpic(issue *models.Issue, epicNameID, epicLinkID string
 	}
 
 	fmt.Println()
+}
+
+// humanSize renders a byte count as a short human-readable string (e.g. "12.3 KB").
+func humanSize(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(unit), 0
+	for x := n / unit; x >= unit; x /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(n)/float64(div), "KMGTPE"[exp])
 }
 
 func printField(label, value string) {

--- a/cmd/issue/issue.go
+++ b/cmd/issue/issue.go
@@ -23,4 +23,5 @@ func init() {
 	IssueCmd.AddCommand(commentListCmd)
 	IssueCmd.AddCommand(commentEditCmd)
 	IssueCmd.AddCommand(commentDeleteCmd)
+	IssueCmd.AddCommand(attachmentCmd)
 }

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -85,6 +85,10 @@ func runMCPServe(cmd *cobra.Command, args []string) error {
 			mcp.WithString("parent", mcp.Description("Parent issue key for Sub-task creation (e.g. ESA-65)")),
 			mcp.WithString("epic_name", mcp.Description("Epic Name (required when type is Epic)")),
 			mcp.WithString("epic_link", mcp.Description("Epic key to associate this issue with (e.g. ESA-42)")),
+			mcp.WithArray("attachments",
+				mcp.WithStringItems(),
+				mcp.Description("Optional list of file paths to attach after creation. Paths are read on the host running this MCP server, not on the agent's client machine."),
+			),
 			mcp.WithString("format", mcp.Description(formatParamDescription)),
 		),
 		createIssueHandler(jc),
@@ -100,6 +104,10 @@ func runMCPServe(cmd *cobra.Command, args []string) error {
 			mcp.WithString("priority", mcp.Description("New priority name")),
 			mcp.WithString("epic_name", mcp.Description("New Epic Name (only for Epics)")),
 			mcp.WithString("epic_link", mcp.Description("New Epic key to link to (empty string to detach)")),
+			mcp.WithArray("attachments",
+				mcp.WithStringItems(),
+				mcp.Description("Optional list of file paths to attach (uploaded after the field update). Paths are read on the host running this MCP server."),
+			),
 			mcp.WithString("format", mcp.Description(formatParamDescription)),
 		),
 		editIssueHandler(jc),
@@ -189,6 +197,35 @@ func runMCPServe(cmd *cobra.Command, args []string) error {
 			mcp.WithString("comment_id", mcp.Required(), mcp.Description("Comment ID")),
 		),
 		deleteCommentHandler(jc),
+	)
+
+	s.AddTool(
+		mcp.NewTool("jira_add_attachment",
+			mcp.WithDescription("Upload one or more files to a Jira issue. Paths are read on the host running this MCP server, not on the agent's client machine — agents should pass paths reachable from that host."),
+			mcp.WithString("key", mcp.Required(), mcp.Description("Issue key (e.g. ESA-123)")),
+			mcp.WithArray("paths",
+				mcp.Required(),
+				mcp.WithStringItems(),
+				mcp.Description("List of file paths to upload"),
+			),
+		),
+		addAttachmentHandler(jc),
+	)
+
+	s.AddTool(
+		mcp.NewTool("jira_list_attachments",
+			mcp.WithDescription("List attachments on a Jira issue"),
+			mcp.WithString("key", mcp.Required(), mcp.Description("Issue key (e.g. ESA-123)")),
+		),
+		listAttachmentsHandler(jc),
+	)
+
+	s.AddTool(
+		mcp.NewTool("jira_delete_attachment",
+			mcp.WithDescription("Delete an attachment by its ID (numeric, as returned by jira_list_attachments)"),
+			mcp.WithString("attachment_id", mcp.Required(), mcp.Description("Attachment ID")),
+		),
+		deleteAttachmentHandler(jc),
 	)
 
 	s.AddTool(
@@ -300,6 +337,28 @@ func isMarkdownFormat(format string) bool {
 }
 
 const formatParamDescription = `Input format for free-form text fields ("wiki" default, or "markdown" to convert from Markdown to Jira Wiki Markup before sending)`
+
+// getStringArray extracts a []string from the MCP request arguments under name.
+// MCP transports an array param as []any, so we narrow it element by element
+// and ignore non-string entries to be tolerant of loose agent encodings.
+func getStringArray(req mcp.CallToolRequest, name string) []string {
+	args := req.GetArguments()
+	raw, ok := args[name]
+	if !ok {
+		return nil
+	}
+	arr, ok := raw.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(arr))
+	for _, v := range arr {
+		if s, ok := v.(string); ok && s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}
 
 func toJSON(v any) string {
 	data, err := json.MarshalIndent(v, "", "  ")
@@ -430,6 +489,21 @@ func createIssueHandler(jc *client.Client) server.ToolHandlerFunc {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
 
+		// Attachments go in a follow-up multipart call; Jira's /issue endpoint
+		// does not accept files. Failure is reported with the created key so
+		// callers can retry with jira_add_attachment.
+		if paths := getStringArray(req, "attachments"); len(paths) > 0 {
+			uploaded, err := jc.AddAttachments(ctx, resp.Key, paths)
+			if err != nil {
+				return mcp.NewToolResultError(fmt.Sprintf("created %s but failed to upload attachments: %s", resp.Key, err)), nil
+			}
+			out := struct {
+				*models.CreateIssueResponse
+				Attachments []models.Attachment `json:"attachments"`
+			}{CreateIssueResponse: resp, Attachments: uploaded}
+			return mcp.NewToolResultText(toJSON(out)), nil
+		}
+
 		return mcp.NewToolResultText(toJSON(resp)), nil
 	}
 }
@@ -494,16 +568,77 @@ func editIssueHandler(jc *client.Client) server.ToolHandlerFunc {
 			}
 		}
 
-		if len(fields) == 0 {
+		paths := getStringArray(req, "attachments")
+		if len(fields) == 0 && len(paths) == 0 {
 			return mcp.NewToolResultError("no fields to update"), nil
 		}
 
-		editReq := &models.EditIssueRequest{Fields: fields}
-		if err := jc.EditIssue(ctx, key, editReq); err != nil {
-			return mcp.NewToolResultError(err.Error()), nil
+		if len(fields) > 0 {
+			editReq := &models.EditIssueRequest{Fields: fields}
+			if err := jc.EditIssue(ctx, key, editReq); err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+		}
+
+		if len(paths) > 0 {
+			uploaded, err := jc.AddAttachments(ctx, key, paths)
+			if err != nil {
+				return mcp.NewToolResultError(fmt.Sprintf("editing %s: %s", key, err)), nil
+			}
+			out := struct {
+				Updated     string              `json:"updated"`
+				Attachments []models.Attachment `json:"attachments"`
+			}{Updated: key, Attachments: uploaded}
+			return mcp.NewToolResultText(toJSON(out)), nil
 		}
 
 		return mcp.NewToolResultText(fmt.Sprintf(`{"updated": "%s"}`, key)), nil
+	}
+}
+
+func addAttachmentHandler(jc *client.Client) server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		key, err := req.RequireString("key")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		paths := getStringArray(req, "paths")
+		if len(paths) == 0 {
+			return mcp.NewToolResultError("paths: at least one file path is required"), nil
+		}
+
+		attachments, err := jc.AddAttachments(ctx, key, paths)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		return mcp.NewToolResultText(toJSON(attachments)), nil
+	}
+}
+
+func listAttachmentsHandler(jc *client.Client) server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		key, err := req.RequireString("key")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		attachments, err := jc.ListAttachments(ctx, key)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		return mcp.NewToolResultText(toJSON(attachments)), nil
+	}
+}
+
+func deleteAttachmentHandler(jc *client.Client) server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		id, err := req.RequireString("attachment_id")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		if err := jc.DeleteAttachment(ctx, id); err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		return mcp.NewToolResultText(fmt.Sprintf(`{"deleted": "%s"}`, id)), nil
 	}
 }
 

--- a/internal/client/attachments_test.go
+++ b/internal/client/attachments_test.go
@@ -1,0 +1,212 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/amplia/jira8/internal/config"
+)
+
+// TestAddAttachments_MultipartBody verifies the multipart body is built
+// correctly: every file ends up as a "file" form part with the right filename
+// and contents, and the required X-Atlassian-Token header is set.
+func TestAddAttachments_MultipartBody(t *testing.T) {
+	tmp := t.TempDir()
+	pathA := filepath.Join(tmp, "alpha.txt")
+	pathB := filepath.Join(tmp, "beta.bin")
+	if err := os.WriteFile(pathA, []byte("alpha-body"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(pathB, []byte{0x01, 0x02, 0x03}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var gotFiles map[string]string
+	var gotXSRF, gotAuth, gotContentType string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/rest/api/2/issue/ESA-1/attachments") {
+			http.NotFound(w, r)
+			return
+		}
+		gotXSRF = r.Header.Get("X-Atlassian-Token")
+		gotAuth = r.Header.Get("Authorization")
+		gotContentType = r.Header.Get("Content-Type")
+
+		if err := r.ParseMultipartForm(1 << 20); err != nil {
+			t.Fatalf("ParseMultipartForm: %v", err)
+		}
+		gotFiles = map[string]string{}
+		for _, fh := range r.MultipartForm.File["file"] {
+			f, err := fh.Open()
+			if err != nil {
+				t.Fatalf("opening part %q: %v", fh.Filename, err)
+			}
+			data, _ := io.ReadAll(f)
+			_ = f.Close()
+			gotFiles[fh.Filename] = string(data)
+		}
+
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{"id": "10", "filename": "alpha.txt", "size": 10},
+			{"id": "11", "filename": "beta.bin", "size": 3},
+		})
+	}))
+	defer srv.Close()
+
+	c := New(&config.Config{URL: srv.URL, Token: "secret"})
+	atts, err := c.AddAttachments(context.Background(), "ESA-1", []string{pathA, pathB})
+	if err != nil {
+		t.Fatalf("AddAttachments: %v", err)
+	}
+	if len(atts) != 2 {
+		t.Fatalf("len(attachments) = %d, want 2", len(atts))
+	}
+
+	if gotXSRF != "no-check" {
+		t.Errorf("X-Atlassian-Token = %q, want no-check", gotXSRF)
+	}
+	if gotAuth != "Bearer secret" {
+		t.Errorf("Authorization = %q, want Bearer secret", gotAuth)
+	}
+	if !strings.HasPrefix(gotContentType, "multipart/form-data") {
+		t.Errorf("Content-Type = %q, want multipart/form-data prefix", gotContentType)
+	}
+	if got := gotFiles["alpha.txt"]; got != "alpha-body" {
+		t.Errorf("alpha.txt body = %q, want alpha-body", got)
+	}
+	if got := gotFiles["beta.bin"]; len(got) != 3 || got[0] != 0x01 {
+		t.Errorf("beta.bin body = %v, want 3 bytes starting with 0x01", []byte(got))
+	}
+}
+
+// TestAddAttachments_MissingFile guarantees the call fails locally without
+// hitting the network when one of the paths doesn't exist.
+func TestAddAttachments_MissingFile(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+	defer srv.Close()
+
+	c := New(&config.Config{URL: srv.URL, Token: "x"})
+	_, err := c.AddAttachments(context.Background(), "ESA-1", []string{"/no/such/file.png"})
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+	if called {
+		t.Error("server was contacted; expected pre-validation to abort the call")
+	}
+}
+
+func TestAddAttachments_NoFiles(t *testing.T) {
+	c := New(&config.Config{URL: "http://localhost", Token: "x"})
+	if _, err := c.AddAttachments(context.Background(), "ESA-1", nil); err == nil {
+		t.Fatal("expected error when no files are passed, got nil")
+	}
+}
+
+// TestAddAttachments_DirectoryRejected ensures we don't try to upload directories.
+func TestAddAttachments_DirectoryRejected(t *testing.T) {
+	dir := t.TempDir()
+	c := New(&config.Config{URL: "http://localhost", Token: "x"})
+	_, err := c.AddAttachments(context.Background(), "ESA-1", []string{dir})
+	if err == nil {
+		t.Fatal("expected error when passing a directory, got nil")
+	}
+}
+
+func TestListAttachments(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/rest/api/2/issue/ESA-2") {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":  "1",
+			"key": "ESA-2",
+			"fields": map[string]any{
+				"summary": "with attachments",
+				"attachment": []map[string]any{
+					{"id": "100", "filename": "report.pdf", "size": 4096},
+					{"id": "101", "filename": "trace.log", "size": 1024},
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	c := New(&config.Config{URL: srv.URL, Token: "x"})
+	atts, err := c.ListAttachments(context.Background(), "ESA-2")
+	if err != nil {
+		t.Fatalf("ListAttachments: %v", err)
+	}
+	if len(atts) != 2 {
+		t.Fatalf("len = %d, want 2", len(atts))
+	}
+	if atts[0].Filename != "report.pdf" || atts[0].Size != 4096 {
+		t.Errorf("attachment[0] = %+v", atts[0])
+	}
+}
+
+func TestDeleteAttachment(t *testing.T) {
+	var gotMethod, gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	c := New(&config.Config{URL: srv.URL, Token: "x"})
+	if err := c.DeleteAttachment(context.Background(), "12345"); err != nil {
+		t.Fatalf("DeleteAttachment: %v", err)
+	}
+	if gotMethod != http.MethodDelete {
+		t.Errorf("method = %q, want DELETE", gotMethod)
+	}
+	if !strings.HasSuffix(gotPath, "/rest/api/2/attachment/12345") {
+		t.Errorf("path = %q, want suffix /rest/api/2/attachment/12345", gotPath)
+	}
+}
+
+// TestAddAttachments_ServerError verifies that a 4xx response surfaces as an
+// APIError carrying the Jira error messages.
+func TestAddAttachments_ServerError(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "x.txt")
+	if err := os.WriteFile(path, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"errorMessages": []string{"XSRF check failed"},
+		})
+	}))
+	defer srv.Close()
+
+	c := New(&config.Config{URL: srv.URL, Token: "x"})
+	_, err := c.AddAttachments(context.Background(), "ESA-1", []string{path})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	apiErr, ok := err.(*APIError)
+	if !ok {
+		t.Fatalf("err type = %T, want *APIError", err)
+	}
+	if apiErr.StatusCode != http.StatusForbidden {
+		t.Errorf("status = %d, want 403", apiErr.StatusCode)
+	}
+	if !strings.Contains(apiErr.Error(), "XSRF check failed") {
+		t.Errorf("error message = %q, want it to mention XSRF", apiErr.Error())
+	}
+}

--- a/internal/client/jira.go
+++ b/internal/client/jira.go
@@ -55,6 +55,10 @@ type Client struct {
 	baseURL    string
 	authHeader string
 	httpClient *http.Client
+	// uploadClient is used for multipart attachment uploads. It has no
+	// total-request timeout so large files on slow links are not aborted
+	// after the global 15s; callers must supply a context to bound the call.
+	uploadClient *http.Client
 }
 
 // New creates a new Jira API client from config.
@@ -70,6 +74,7 @@ func New(cfg *config.Config) *Client {
 		httpClient: &http.Client{
 			Timeout: 15 * time.Second,
 		},
+		uploadClient: &http.Client{},
 	}
 }
 
@@ -331,6 +336,47 @@ func (c *Client) GetComments(ctx context.Context, key string) ([]models.Comment,
 		return nil, fmt.Errorf("parsing comments: %w", err)
 	}
 	return resp.Comments, nil
+}
+
+// AddAttachments uploads one or more files to an issue.
+// Files are streamed via multipart/form-data; the call requires
+// X-Atlassian-Token: no-check (Jira XSRF protection).
+// Paths are resolved on the host running this process — when invoked through
+// the MCP server, that means the server host, not the AI agent's client.
+func (c *Client) AddAttachments(ctx context.Context, key string, files []string) ([]models.Attachment, error) {
+	if len(files) == 0 {
+		return nil, fmt.Errorf("no files to upload")
+	}
+	path := "/issue/" + url.PathEscape(key) + "/attachments"
+	data, err := c.doMultipartUpload(ctx, path, files)
+	if err != nil {
+		return nil, err
+	}
+
+	var attachments []models.Attachment
+	if err := json.Unmarshal(data, &attachments); err != nil {
+		return nil, fmt.Errorf("parsing attachment response: %w", err)
+	}
+	return attachments, nil
+}
+
+// ListAttachments returns all attachments on an issue. Jira already includes
+// the attachment list in the standard issue payload, so this is a thin wrapper
+// over GetIssue that surfaces fields.attachment as the primary return value.
+func (c *Client) ListAttachments(ctx context.Context, key string) ([]models.Attachment, error) {
+	issue, err := c.GetIssue(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+	return issue.Fields.Attachment, nil
+}
+
+// DeleteAttachment removes an attachment by its ID. The ID is the numeric
+// attachment identifier returned by AddAttachments / ListAttachments — not
+// the issue key. The endpoint lives outside /issue (DELETE /attachment/{id}).
+func (c *Client) DeleteAttachment(ctx context.Context, attachmentID string) error {
+	_, err := c.do(ctx, http.MethodDelete, "/attachment/"+url.PathEscape(attachmentID), nil)
+	return err
 }
 
 // GetMyself returns the currently authenticated user.

--- a/internal/client/multipart.go
+++ b/internal/client/multipart.go
@@ -1,0 +1,109 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/amplia/jira8/internal/models"
+)
+
+// doMultipartUpload posts one or more files to a Jira multipart endpoint
+// (currently only /issue/{key}/attachments). Files are streamed using io.Pipe
+// so large attachments do not need to be buffered in memory.
+//
+// Requires the X-Atlassian-Token: no-check header, which Jira mandates for
+// attachment uploads to defeat XSRF protection. Without it the server replies
+// 403 with an XSRF error.
+//
+// Retries are not attempted: the request body is a one-shot pipe and the
+// underlying os.File readers cannot be rewound safely. Callers see network
+// or HTTP errors as-is.
+func (c *Client) doMultipartUpload(ctx context.Context, path string, files []string) ([]byte, error) {
+	// Pre-validate every path before opening the request so we fail fast
+	// without leaking file handles or sending a half-built multipart body.
+	for _, p := range files {
+		info, err := os.Stat(p)
+		if err != nil {
+			return nil, fmt.Errorf("attachment %q: %w", p, err)
+		}
+		if info.IsDir() {
+			return nil, fmt.Errorf("attachment %q is a directory", p)
+		}
+	}
+
+	pr, pw := io.Pipe()
+	mw := multipart.NewWriter(pw)
+
+	go func() {
+		var err error
+		defer func() {
+			// Closing the writer flushes the trailing boundary; closing the
+			// pipe end signals EOF (or the error) to the HTTP transport.
+			if cerr := mw.Close(); err == nil {
+				err = cerr
+			}
+			_ = pw.CloseWithError(err)
+		}()
+
+		for _, p := range files {
+			var f *os.File
+			f, err = os.Open(p)
+			if err != nil {
+				return
+			}
+			var part io.Writer
+			part, err = mw.CreateFormFile("file", filepath.Base(p))
+			if err != nil {
+				_ = f.Close()
+				return
+			}
+			if _, err = io.Copy(part, f); err != nil {
+				_ = f.Close()
+				return
+			}
+			if err = f.Close(); err != nil {
+				return
+			}
+		}
+	}()
+
+	fullURL := c.baseURL + apiBasePath + path
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fullURL, pr)
+	if err != nil {
+		_ = pr.Close()
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Authorization", c.authHeader)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("X-Atlassian-Token", "no-check")
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+
+	resp, err := c.uploadClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("executing request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response body: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		apiErr := &APIError{StatusCode: resp.StatusCode}
+		var jiraErr models.JiraError
+		if json.Unmarshal(respBody, &jiraErr) == nil {
+			apiErr.Messages = jiraErr.ErrorMessages
+			apiErr.Errors = jiraErr.Errors
+		}
+		return nil, apiErr
+	}
+
+	return respBody, nil
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -39,6 +39,7 @@ type IssueFields struct {
 	Labels      []string        `json:"labels,omitempty"`
 	Components  []Component     `json:"components,omitempty"`
 	Comment     *Comments       `json:"comment,omitempty"`
+	Attachment  []Attachment    `json:"attachment,omitempty"`
 	Raw         json.RawMessage `json:"-"`
 }
 
@@ -327,6 +328,20 @@ type WorklogsResponse struct {
 	MaxResults int       `json:"maxResults"`
 	Total      int       `json:"total"`
 	Worklogs   []Worklog `json:"worklogs"`
+}
+
+// Attachment represents a Jira issue attachment (returned in IssueFields.Attachment
+// and by POST /rest/api/2/issue/{key}/attachments).
+type Attachment struct {
+	ID        string `json:"id"`
+	Self      string `json:"self,omitempty"`
+	Filename  string `json:"filename"`
+	Author    *User  `json:"author,omitempty"`
+	Created   string `json:"created,omitempty"`
+	Size      int64  `json:"size,omitempty"`
+	MimeType  string `json:"mimeType,omitempty"`
+	Content   string `json:"content,omitempty"`
+	Thumbnail string `json:"thumbnail,omitempty"`
 }
 
 // JiraError represents a Jira API error response.


### PR DESCRIPTION
## Summary
- Adds full attachment lifecycle on issues: three new MCP tools (`jira_add_attachment`, `jira_list_attachments`, `jira_delete_attachment`) and a matching `issue attachment add|list|delete` CLI subcommand.
- Adds repeatable `--attach FILE` to `issue create` and `issue edit` (and `attachments[]` to the equivalent MCP tools), so files can be uploaded in the same invocation that creates or modifies the issue.
- Renders an "Attachments" section in `issue view` when present.

## Implementation notes
- Streaming multipart via `io.Pipe` + goroutine — no in-memory buffering of large files.
- A dedicated `uploadClient` (no total timeout) backs uploads so slow links don't trip the 15s global timeout; cancellation flows through `context.Context`.
- `X-Atlassian-Token: no-check` set as Jira XSRF protection requires.
- Non-transactional create+upload: if the issue is created but the attachment upload fails, the new key is surfaced with the upload error so the user can retry via `issue attachment add`.
- README documents the CLI + MCP surface and includes a security note: paths are read on the host running `jira8 mcp serve`, not the agent's client machine.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (8 new tests in `internal/client/attachments_test.go`: multipart body, missing file, no files, directory rejected, list, delete, 403 server error)
- [ ] Smoke against real Jira (`TEST` project): create with `--attach`, edit with `--attach`, attachment list, attachment delete

Closes #30