### PR TITLE
Add `issue link` / `link-types` commands (CLI + MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,18 @@ jira8 issue transitions MYPROJ-123               # list available transitions
 jira8 issue transition MYPROJ-123 --to "Done"    # perform transition
 ```
 
+### Links
+
+```bash
+jira8 issue link-types                                   # list available link types
+jira8 issue link MYPROJ-1 MYPROJ-2 --type "Relates"      # relate two issues
+jira8 issue link MYPROJ-9 MYPROJ-10 --type "Blocks"      # MYPROJ-9 blocks MYPROJ-10
+jira8 issue link A B --type "Relates" --comment "note"   # with an optional comment
+```
+
+The first key is the subject of the relation ("OUTWARD *phrase* INWARD"); for symmetric
+types like `Relates` the order is irrelevant. `--type` defaults to `Relates`.
+
 ### Comments
 
 ```bash

--- a/cmd/issue/issue.go
+++ b/cmd/issue/issue.go
@@ -24,4 +24,6 @@ func init() {
 	IssueCmd.AddCommand(commentEditCmd)
 	IssueCmd.AddCommand(commentDeleteCmd)
 	IssueCmd.AddCommand(attachmentCmd)
+	IssueCmd.AddCommand(linkCmd)
+	IssueCmd.AddCommand(linkTypesCmd)
 }

--- a/cmd/issue/link.go
+++ b/cmd/issue/link.go
@@ -1,0 +1,120 @@
+package issue
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/amplia/jira8/cmd/app"
+	"github.com/amplia/jira8/internal/models"
+	"github.com/spf13/cobra"
+)
+
+var linkCmd = &cobra.Command{
+	Use:   "link OUTWARD-KEY INWARD-KEY",
+	Short: "Link two issues (e.g. Relates, Blocks, Duplicate)",
+	Long: "Create a link between two issues. The first key is the subject of the " +
+		"relationship and the second its object (\"OUTWARD <phrase> INWARD\", e.g. " +
+		"\"ESA-207 blocks ESA-214\"). For symmetric types like Relates the order is irrelevant.\n\n" +
+		"Run 'jira8 issue link-types' to see the available type names.",
+	Example: "  jira8 issue link ESA-207 ESA-214 --type \"Relates\"\n" +
+		"  jira8 issue link ESA-9 ESA-10 --type \"Blocks\" --comment \"blocked until merge\"",
+	Args: cobra.ExactArgs(2),
+	RunE: runLink,
+}
+
+var linkTypesCmd = &cobra.Command{
+	Use:     "link-types",
+	Short:   "List the available issue link types",
+	Example: "  jira8 issue link-types",
+	Args:    cobra.NoArgs,
+	RunE:    runLinkTypes,
+}
+
+func init() {
+	linkCmd.Flags().String("type", "Relates", "Link type name (e.g. Relates, Blocks, Duplicate)")
+	linkCmd.Flags().String("comment", "", "Optional comment to add alongside the link")
+}
+
+func runLink(cmd *cobra.Command, args []string) error {
+	a := app.Get()
+	outward, inward := args[0], args[1]
+	typeName, _ := cmd.Flags().GetString("type")
+	comment, _ := cmd.Flags().GetString("comment")
+
+	// Validate the link type against the configured ones so the user gets a
+	// helpful error listing the valid names (same UX as 'issue transition').
+	types, err := a.Client.GetIssueLinkTypes(context.Background())
+	if err != nil {
+		return err
+	}
+	match := matchLinkType(types, typeName)
+	if match == nil {
+		return fmt.Errorf("link type %q not found; available: %s", typeName, strings.Join(linkTypeNames(types), ", "))
+	}
+
+	req := &models.IssueLinkRequest{
+		Type:         models.IssueLinkTypeRef{Name: match.Name},
+		OutwardIssue: models.LinkedIssueRef{Key: outward},
+		InwardIssue:  models.LinkedIssueRef{Key: inward},
+	}
+	if comment != "" {
+		req.Comment = &models.IssueLinkComment{Body: comment}
+	}
+	if err := a.Client.LinkIssues(context.Background(), req); err != nil {
+		return err
+	}
+
+	fmt.Printf("Linked %s %s %s\n", outward, match.Outward, inward)
+	return nil
+}
+
+func runLinkTypes(cmd *cobra.Command, args []string) error {
+	a := app.Get()
+	types, err := a.Client.GetIssueLinkTypes(context.Background())
+	if err != nil {
+		return err
+	}
+
+	if a.Output == "json" {
+		data, err := json.MarshalIndent(types, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(data))
+		return nil
+	}
+
+	if len(types) == 0 {
+		fmt.Println("No issue link types available.")
+		return nil
+	}
+	fmt.Printf("%s  %s  %s\n",
+		headerStyle.Render(fmt.Sprintf("%-16s", "NAME")),
+		headerStyle.Render(fmt.Sprintf("%-24s", "OUTWARD")),
+		headerStyle.Render("INWARD"),
+	)
+	for _, t := range types {
+		fmt.Printf("%-16s  %-24s  %s\n", t.Name, t.Outward, t.Inward)
+	}
+	return nil
+}
+
+// matchLinkType returns the link type whose name matches (case-insensitive), or nil.
+func matchLinkType(types []models.IssueLinkType, name string) *models.IssueLinkType {
+	for i := range types {
+		if strings.EqualFold(types[i].Name, name) {
+			return &types[i]
+		}
+	}
+	return nil
+}
+
+func linkTypeNames(types []models.IssueLinkType) []string {
+	names := make([]string, len(types))
+	for i, t := range types {
+		names[i] = t.Name
+	}
+	return names
+}

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -131,6 +131,24 @@ func runMCPServe(cmd *cobra.Command, args []string) error {
 	)
 
 	s.AddTool(
+		mcp.NewTool("jira_link_issues",
+			mcp.WithDescription("Link two Jira issues (e.g. Relates, Blocks, Duplicate). The type must be one of the names returned by jira_list_link_types; defaults to Relates."),
+			mcp.WithString("outward", mcp.Required(), mcp.Description("Outward issue key — subject of the relation, e.g. the one that 'blocks' (e.g. ESA-207)")),
+			mcp.WithString("inward", mcp.Required(), mcp.Description("Inward issue key — object of the relation, e.g. the one that 'is blocked by' (e.g. ESA-214)")),
+			mcp.WithString("type", mcp.Description("Link type name; defaults to 'Relates'")),
+			mcp.WithString("comment", mcp.Description("Optional comment added alongside the link")),
+		),
+		linkIssuesHandler(jc),
+	)
+
+	s.AddTool(
+		mcp.NewTool("jira_list_link_types",
+			mcp.WithDescription("List the available issue link types in the Jira instance"),
+		),
+		listLinkTypesHandler(jc),
+	)
+
+	s.AddTool(
 		mcp.NewTool("jira_add_worklog",
 			mcp.WithDescription("Add a worklog entry to a Jira issue"),
 			mcp.WithString("key", mcp.Required(), mcp.Description("Issue key (e.g. ESA-123)")),
@@ -736,6 +754,63 @@ func transitionIssueHandler(jc *client.Client) server.ToolHandlerFunc {
 			target = match.To.Name
 		}
 		return mcp.NewToolResultText(fmt.Sprintf(`{"transitioned": "%s", "to": "%s"}`, key, target)), nil
+	}
+}
+
+func linkIssuesHandler(jc *client.Client) server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		outward, err := req.RequireString("outward")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		inward, err := req.RequireString("inward")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		typeName := req.GetString("type", "Relates")
+		comment := req.GetString("comment", "")
+
+		types, err := jc.GetIssueLinkTypes(ctx)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		var match *models.IssueLinkType
+		for i := range types {
+			if strings.EqualFold(types[i].Name, typeName) {
+				match = &types[i]
+				break
+			}
+		}
+		if match == nil {
+			names := make([]string, len(types))
+			for i, t := range types {
+				names[i] = t.Name
+			}
+			return mcp.NewToolResultError(fmt.Sprintf("link type %q not found; available: %s", typeName, strings.Join(names, ", "))), nil
+		}
+
+		linkReq := &models.IssueLinkRequest{
+			Type:         models.IssueLinkTypeRef{Name: match.Name},
+			OutwardIssue: models.LinkedIssueRef{Key: outward},
+			InwardIssue:  models.LinkedIssueRef{Key: inward},
+		}
+		if comment != "" {
+			linkReq.Comment = &models.IssueLinkComment{Body: comment}
+		}
+		if err := jc.LinkIssues(ctx, linkReq); err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		return mcp.NewToolResultText(fmt.Sprintf(`{"linked": true, "outward": %q, "type": %q, "inward": %q}`, outward, match.Name, inward)), nil
+	}
+}
+
+func listLinkTypesHandler(jc *client.Client) server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		types, err := jc.GetIssueLinkTypes(ctx)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		return mcp.NewToolResultText(toJSON(types)), nil
 	}
 }
 

--- a/internal/client/jira.go
+++ b/internal/client/jira.go
@@ -253,6 +253,25 @@ func (c *Client) DoTransition(ctx context.Context, key string, req *models.Trans
 	return err
 }
 
+// GetIssueLinkTypes returns the issue link types configured in the Jira instance.
+func (c *Client) GetIssueLinkTypes(ctx context.Context) ([]models.IssueLinkType, error) {
+	data, err := c.do(ctx, http.MethodGet, "/issueLinkType", nil)
+	if err != nil {
+		return nil, err
+	}
+	var resp models.IssueLinkTypesResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return nil, fmt.Errorf("parsing issue link types: %w", err)
+	}
+	return resp.IssueLinkTypes, nil
+}
+
+// LinkIssues creates a link between two issues (POST /issueLink).
+func (c *Client) LinkIssues(ctx context.Context, req *models.IssueLinkRequest) error {
+	_, err := c.do(ctx, http.MethodPost, "/issueLink", req)
+	return err
+}
+
 // AddWorklog adds a worklog entry to an issue.
 func (c *Client) AddWorklog(ctx context.Context, key string, req *models.AddWorklogRequest) (*models.Worklog, error) {
 	data, err := c.do(ctx, http.MethodPost, "/issue/"+url.PathEscape(key)+"/worklog", req)

--- a/internal/client/link_test.go
+++ b/internal/client/link_test.go
@@ -1,0 +1,108 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/amplia/jira8/internal/config"
+	"github.com/amplia/jira8/internal/models"
+)
+
+// TestGetIssueLinkTypes verifies the GET /issueLinkType response is parsed into
+// the typed slice.
+func TestGetIssueLinkTypes(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/rest/api/2/issueLinkType") {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issueLinkTypes": []map[string]any{
+				{"id": "10000", "name": "Blocks", "inward": "is blocked by", "outward": "blocks"},
+				{"id": "10001", "name": "Relates", "inward": "relates to", "outward": "relates to"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	c := New(&config.Config{URL: srv.URL, Token: "secret"})
+	types, err := c.GetIssueLinkTypes(context.Background())
+	if err != nil {
+		t.Fatalf("GetIssueLinkTypes: %v", err)
+	}
+	if len(types) != 2 {
+		t.Fatalf("len(types) = %d, want 2", len(types))
+	}
+	if types[1].Name != "Relates" || types[1].Outward != "relates to" {
+		t.Errorf("unexpected type[1]: %+v", types[1])
+	}
+}
+
+// TestLinkIssues_PostsBody verifies LinkIssues POSTs the correct body to
+// /issueLink with the type, both issue keys and the optional comment.
+func TestLinkIssues_PostsBody(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotBody models.IssueLinkRequest
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		data, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(data, &gotBody)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	c := New(&config.Config{URL: srv.URL, Token: "secret"})
+	req := &models.IssueLinkRequest{
+		Type:         models.IssueLinkTypeRef{Name: "Relates"},
+		OutwardIssue: models.LinkedIssueRef{Key: "ESA-207"},
+		InwardIssue:  models.LinkedIssueRef{Key: "ESA-214"},
+		Comment:      &models.IssueLinkComment{Body: "same work"},
+	}
+	if err := c.LinkIssues(context.Background(), req); err != nil {
+		t.Fatalf("LinkIssues: %v", err)
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %s, want POST", gotMethod)
+	}
+	if !strings.HasSuffix(gotPath, "/rest/api/2/issueLink") {
+		t.Errorf("path = %s, want suffix /rest/api/2/issueLink", gotPath)
+	}
+	if gotBody.Type.Name != "Relates" {
+		t.Errorf("type = %q, want Relates", gotBody.Type.Name)
+	}
+	if gotBody.OutwardIssue.Key != "ESA-207" || gotBody.InwardIssue.Key != "ESA-214" {
+		t.Errorf("issues = %s / %s, want ESA-207 / ESA-214", gotBody.OutwardIssue.Key, gotBody.InwardIssue.Key)
+	}
+	if gotBody.Comment == nil || gotBody.Comment.Body != "same work" {
+		t.Errorf("comment = %+v, want body 'same work'", gotBody.Comment)
+	}
+}
+
+// TestLinkIssues_APIError verifies a Jira 4xx is surfaced as a Go error.
+func TestLinkIssues_APIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"errorMessages": []string{"No issue link type with name 'Nope' found"},
+		})
+	}))
+	defer srv.Close()
+
+	c := New(&config.Config{URL: srv.URL, Token: "secret"})
+	err := c.LinkIssues(context.Background(), &models.IssueLinkRequest{
+		Type:         models.IssueLinkTypeRef{Name: "Nope"},
+		OutwardIssue: models.LinkedIssueRef{Key: "ESA-1"},
+		InwardIssue:  models.LinkedIssueRef{Key: "ESA-2"},
+	})
+	if err == nil {
+		t.Fatal("LinkIssues: expected error on HTTP 400, got nil")
+	}
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -274,6 +274,47 @@ type TransitionRef struct {
 	ID string `json:"id"`
 }
 
+// IssueLinkType is a Jira issue link type (e.g. "Relates", "Blocks").
+// Inward/Outward are the human-readable relationship phrases
+// (e.g. "is blocked by" / "blocks").
+type IssueLinkType struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Inward  string `json:"inward"`
+	Outward string `json:"outward"`
+}
+
+// IssueLinkTypesResponse is the response from GET /rest/api/2/issueLinkType.
+type IssueLinkTypesResponse struct {
+	IssueLinkTypes []IssueLinkType `json:"issueLinkTypes"`
+}
+
+// IssueLinkTypeRef references a link type by name in a link request.
+type IssueLinkTypeRef struct {
+	Name string `json:"name"`
+}
+
+// LinkedIssueRef references an issue by key inside an issue-link request.
+type LinkedIssueRef struct {
+	Key string `json:"key"`
+}
+
+// IssueLinkComment is an optional comment posted alongside an issue link.
+type IssueLinkComment struct {
+	Body string `json:"body"`
+}
+
+// IssueLinkRequest is the POST body for /rest/api/2/issueLink. The outward
+// issue is the subject of the relationship ("OUTWARD <outward-phrase> INWARD",
+// e.g. "ESA-207 blocks ESA-214"). For symmetric types like "Relates" the
+// direction is irrelevant.
+type IssueLinkRequest struct {
+	Type         IssueLinkTypeRef  `json:"type"`
+	InwardIssue  LinkedIssueRef    `json:"inwardIssue"`
+	OutwardIssue LinkedIssueRef    `json:"outwardIssue"`
+	Comment      *IssueLinkComment `json:"comment,omitempty"`
+}
+
 // CreateIssueResponse is the response from POST /rest/api/2/issue.
 type CreateIssueResponse struct {
 	ID   string `json:"id"`


### PR DESCRIPTION
Closes #52.

## What

Adds first-class **issue link** support to both surfaces (CLI ↔ MCP parity):

- `jira8 issue link OUTWARD-KEY INWARD-KEY --type "Relates" [--comment "..."]` — create a link between two issues. Validates the type against the configured ones and returns a helpful error listing them (same UX as `transition`). First positional arg is the subject of the relation ("A *relates to* B"); `--type` defaults to `Relates`.
- `jira8 issue link-types` — list the available link types (like `transitions`).
- MCP tools: `jira_link_issues` and `jira_list_link_types`.

## How

- Client: `GetIssueLinkTypes` (GET `/issueLinkType`) and `LinkIssues` (POST `/issueLink`) via the existing `do()` helper.
- Models: `IssueLinkType`, `IssueLinkRequest` (Jira Server 8 `{"name": ...}` refs, optional wiki-markup comment).
- README updated with a Links section.

## Test plan

- `go build ./...`, `go vet ./...`, `go test ./...` — all green.
- New `internal/client/link_test.go`: link-type parsing, `LinkIssues` body/method/path, and API-error surfacing (httptest).