### PR TITLE
refactor: tech-debt sweep (DRY, dead code, lint, modernize)

### DIFF
--- a/cmd/app/match.go
+++ b/cmd/app/match.go
@@ -1,0 +1,25 @@
+package app
+
+import "strings"
+
+// MatchByName returns a pointer to the first item whose name (extracted via
+// nameOf) matches target case-insensitively, or nil if none match. It backs the
+// "resolve a transition / link type by name" lookups shared by the CLI and MCP.
+func MatchByName[T any](items []T, target string, nameOf func(T) string) *T {
+	for i := range items {
+		if strings.EqualFold(nameOf(items[i]), target) {
+			return &items[i]
+		}
+	}
+	return nil
+}
+
+// Names maps items to their names via nameOf, preserving order. Used to build
+// the "available: a, b, c" hint when a name lookup fails.
+func Names[T any](items []T, nameOf func(T) string) []string {
+	out := make([]string, len(items))
+	for i := range items {
+		out[i] = nameOf(items[i])
+	}
+	return out
+}

--- a/cmd/app/output.go
+++ b/cmd/app/output.go
@@ -1,0 +1,18 @@
+package app
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// OutputJSON marshals v as indented JSON and prints it to stdout. It is the
+// single implementation behind every `if a.Output == "json"` branch in the
+// CLI subcommands, so the JSON output format stays consistent across commands.
+func OutputJSON(v any) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(data))
+	return nil
+}

--- a/cmd/epic/children.go
+++ b/cmd/epic/children.go
@@ -2,7 +2,6 @@ package epic
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/amplia/jira8/cmd/app"
@@ -39,12 +38,7 @@ func runChildren(cmd *cobra.Command, args []string) error {
 	}
 
 	if a.Output == "json" {
-		data, err := json.MarshalIndent(issues, "", "  ")
-		if err != nil {
-			return err
-		}
-		fmt.Println(string(data))
-		return nil
+		return app.OutputJSON(issues)
 	}
 
 	if len(issues) == 0 {

--- a/cmd/epic/create.go
+++ b/cmd/epic/create.go
@@ -2,9 +2,7 @@ package epic
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/amplia/jira8/cmd/app"
 	"github.com/amplia/jira8/internal/markup"
@@ -68,13 +66,9 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	}
 
 	if assignee != "" {
-		username := assignee
-		if strings.EqualFold(assignee, "me") {
-			user, err := a.Client.GetMyself(context.Background())
-			if err != nil {
-				return fmt.Errorf("resolving current user: %w", err)
-			}
-			username = user.Name
+		username, err := a.Client.ResolveAssignee(context.Background(), assignee)
+		if err != nil {
+			return err
 		}
 		req.Fields.Assignee = &models.UserRef{Name: username}
 	}
@@ -89,12 +83,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	}
 
 	if a.Output == "json" {
-		data, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return err
-		}
-		fmt.Println(string(data))
-		return nil
+		return app.OutputJSON(resp)
 	}
 
 	fmt.Printf("Created Epic %s\n", resp.Key)

--- a/cmd/epic/edit.go
+++ b/cmd/epic/edit.go
@@ -3,7 +3,6 @@ package epic
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/amplia/jira8/cmd/app"
 	"github.com/amplia/jira8/internal/markup"
@@ -61,13 +60,9 @@ func runEdit(cmd *cobra.Command, args []string) error {
 		if v == "" {
 			fields["assignee"] = nil
 		} else {
-			username := v
-			if strings.EqualFold(v, "me") {
-				user, err := a.Client.GetMyself(context.Background())
-				if err != nil {
-					return fmt.Errorf("resolving current user: %w", err)
-				}
-				username = user.Name
+			username, err := a.Client.ResolveAssignee(context.Background(), v)
+			if err != nil {
+				return err
 			}
 			fields["assignee"] = models.UserRef{Name: username}
 		}

--- a/cmd/epic/list.go
+++ b/cmd/epic/list.go
@@ -2,7 +2,6 @@ package epic
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/amplia/jira8/cmd/app"
@@ -59,12 +58,7 @@ func runList(cmd *cobra.Command, args []string) error {
 	}
 
 	if a.Output == "json" {
-		data, err := json.MarshalIndent(issues, "", "  ")
-		if err != nil {
-			return err
-		}
-		fmt.Println(string(data))
-		return nil
+		return app.OutputJSON(issues)
 	}
 
 	printEpicTable(issues, epicNameID)

--- a/cmd/epic/view.go
+++ b/cmd/epic/view.go
@@ -2,7 +2,6 @@ package epic
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -59,12 +58,7 @@ func runView(cmd *cobra.Command, args []string) error {
 			Epic     *models.Issue  `json:"epic"`
 			Children []models.Issue `json:"children,omitempty"`
 		}{Epic: issue, Children: children}
-		data, err := json.MarshalIndent(out, "", "  ")
-		if err != nil {
-			return err
-		}
-		fmt.Println(string(data))
-		return nil
+		return app.OutputJSON(out)
 	}
 
 	printEpicDetail(issue, epicNameID, epicLinkID)

--- a/cmd/issue/attachment.go
+++ b/cmd/issue/attachment.go
@@ -2,7 +2,6 @@ package issue
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/amplia/jira8/cmd/app"
@@ -62,12 +61,7 @@ func runAttachmentAdd(cmd *cobra.Command, args []string) error {
 	}
 
 	if a.Output == "json" {
-		data, err := json.MarshalIndent(attachments, "", "  ")
-		if err != nil {
-			return err
-		}
-		fmt.Println(string(data))
-		return nil
+		return app.OutputJSON(attachments)
 	}
 
 	fmt.Printf("Uploaded %d attachment(s) to %s:\n", len(attachments), key)
@@ -87,12 +81,7 @@ func runAttachmentList(cmd *cobra.Command, args []string) error {
 	}
 
 	if a.Output == "json" {
-		data, err := json.MarshalIndent(attachments, "", "  ")
-		if err != nil {
-			return err
-		}
-		fmt.Println(string(data))
-		return nil
+		return app.OutputJSON(attachments)
 	}
 
 	if len(attachments) == 0 {

--- a/cmd/issue/comment_add.go
+++ b/cmd/issue/comment_add.go
@@ -2,7 +2,6 @@ package issue
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/amplia/jira8/cmd/app"
@@ -49,12 +48,7 @@ func runCommentAdd(cmd *cobra.Command, args []string) error {
 	}
 
 	if a.Output == "json" {
-		data, err := json.MarshalIndent(comment, "", "  ")
-		if err != nil {
-			return err
-		}
-		fmt.Println(string(data))
-		return nil
+		return app.OutputJSON(comment)
 	}
 
 	fmt.Printf("Comment added to %s by %s\n", key, userName(comment.Author))

--- a/cmd/issue/comment_edit.go
+++ b/cmd/issue/comment_edit.go
@@ -2,7 +2,6 @@ package issue
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/amplia/jira8/cmd/app"
@@ -49,12 +48,7 @@ func runCommentEdit(cmd *cobra.Command, args []string) error {
 	}
 
 	if a.Output == "json" {
-		data, err := json.MarshalIndent(comment, "", "  ")
-		if err != nil {
-			return err
-		}
-		fmt.Println(string(data))
-		return nil
+		return app.OutputJSON(comment)
 	}
 
 	fmt.Printf("Comment %s updated on %s\n", comment.ID, key)

--- a/cmd/issue/comment_list.go
+++ b/cmd/issue/comment_list.go
@@ -51,7 +51,7 @@ func runCommentList(cmd *cobra.Command, args []string) error {
 			created = created[:10]
 		}
 		fmt.Printf("\n  %s  %s  %s\n", labelStyle.Render("#"+c.ID), headerStyle.Render(userName(c.Author)), labelStyle.Render(created))
-		for _, line := range strings.Split(c.Body, "\n") {
+		for line := range strings.SplitSeq(c.Body, "\n") {
 			fmt.Printf("  %s\n", line)
 		}
 	}

--- a/cmd/issue/comment_list.go
+++ b/cmd/issue/comment_list.go
@@ -2,7 +2,6 @@ package issue
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -37,12 +36,7 @@ func runCommentList(cmd *cobra.Command, args []string) error {
 	}
 
 	if a.Output == "json" {
-		data, err := json.MarshalIndent(comments, "", "  ")
-		if err != nil {
-			return err
-		}
-		fmt.Println(string(data))
-		return nil
+		return app.OutputJSON(comments)
 	}
 
 	if len(comments) == 0 {

--- a/cmd/issue/create.go
+++ b/cmd/issue/create.go
@@ -2,7 +2,6 @@ package issue
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -76,13 +75,9 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	}
 
 	if assignee != "" {
-		username := assignee
-		if strings.EqualFold(assignee, "me") {
-			user, err := a.Client.GetMyself(context.Background())
-			if err != nil {
-				return fmt.Errorf("resolving current user: %w", err)
-			}
-			username = user.Name
+		username, err := a.Client.ResolveAssignee(context.Background(), assignee)
+		if err != nil {
+			return err
 		}
 		req.Fields.Assignee = &models.UserRef{Name: username}
 	}
@@ -132,12 +127,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 			*models.CreateIssueResponse
 			Attachments []models.Attachment `json:"attachments,omitempty"`
 		}{CreateIssueResponse: resp, Attachments: uploaded}
-		data, err := json.MarshalIndent(payload, "", "  ")
-		if err != nil {
-			return err
-		}
-		fmt.Println(string(data))
-		return nil
+		return app.OutputJSON(payload)
 	}
 
 	fmt.Printf("Created %s\n", resp.Key)

--- a/cmd/issue/edit.go
+++ b/cmd/issue/edit.go
@@ -3,7 +3,6 @@ package issue
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/amplia/jira8/cmd/app"
 	"github.com/amplia/jira8/internal/markup"
@@ -56,13 +55,9 @@ func runEdit(cmd *cobra.Command, args []string) error {
 		if v == "" {
 			fields["assignee"] = nil
 		} else {
-			username := v
-			if strings.EqualFold(v, "me") {
-				user, err := a.Client.GetMyself(context.Background())
-				if err != nil {
-					return fmt.Errorf("resolving current user: %w", err)
-				}
-				username = user.Name
+			username, err := a.Client.ResolveAssignee(context.Background(), v)
+			if err != nil {
+				return err
 			}
 			fields["assignee"] = models.UserRef{Name: username}
 		}

--- a/cmd/issue/format.go
+++ b/cmd/issue/format.go
@@ -209,7 +209,7 @@ func printIssueDetailWithEpic(issue *models.Issue, epicNameID, epicLinkID string
 		}
 		for _, c := range comments[start:] {
 			fmt.Printf("\n  %s  %s\n", headerStyle.Render(userName(c.Author)), labelStyle.Render(c.Created))
-			for _, line := range strings.Split(c.Body, "\n") {
+			for line := range strings.SplitSeq(c.Body, "\n") {
 				fmt.Printf("  %s\n", line)
 			}
 		}

--- a/cmd/issue/link.go
+++ b/cmd/issue/link.go
@@ -2,7 +2,6 @@ package issue
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -49,9 +48,9 @@ func runLink(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	match := matchLinkType(types, typeName)
+	match := app.MatchByName(types, typeName, linkTypeName)
 	if match == nil {
-		return fmt.Errorf("link type %q not found; available: %s", typeName, strings.Join(linkTypeNames(types), ", "))
+		return fmt.Errorf("link type %q not found; available: %s", typeName, strings.Join(app.Names(types, linkTypeName), ", "))
 	}
 
 	req := &models.IssueLinkRequest{
@@ -78,12 +77,7 @@ func runLinkTypes(cmd *cobra.Command, args []string) error {
 	}
 
 	if a.Output == "json" {
-		data, err := json.MarshalIndent(types, "", "  ")
-		if err != nil {
-			return err
-		}
-		fmt.Println(string(data))
-		return nil
+		return app.OutputJSON(types)
 	}
 
 	if len(types) == 0 {
@@ -101,20 +95,5 @@ func runLinkTypes(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// matchLinkType returns the link type whose name matches (case-insensitive), or nil.
-func matchLinkType(types []models.IssueLinkType, name string) *models.IssueLinkType {
-	for i := range types {
-		if strings.EqualFold(types[i].Name, name) {
-			return &types[i]
-		}
-	}
-	return nil
-}
-
-func linkTypeNames(types []models.IssueLinkType) []string {
-	names := make([]string, len(types))
-	for i, t := range types {
-		names[i] = t.Name
-	}
-	return names
-}
+// linkTypeName extracts the name of a link type for app.MatchByName / app.Names.
+func linkTypeName(t models.IssueLinkType) string { return t.Name }

--- a/cmd/issue/list.go
+++ b/cmd/issue/list.go
@@ -2,8 +2,6 @@ package issue
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 
 	"github.com/amplia/jira8/cmd/app"
 	"github.com/amplia/jira8/internal/client"
@@ -59,12 +57,7 @@ func runList(cmd *cobra.Command, args []string) error {
 	}
 
 	if app.Get().Output == "json" {
-		data, err := json.MarshalIndent(issues, "", "  ")
-		if err != nil {
-			return err
-		}
-		fmt.Println(string(data))
-		return nil
+		return app.OutputJSON(issues)
 	}
 
 	printIssueTable(issues)

--- a/cmd/issue/transition.go
+++ b/cmd/issue/transition.go
@@ -2,7 +2,6 @@ package issue
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -42,20 +41,10 @@ func runTransition(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	var match *models.Transition
-	for i, t := range transitions {
-		if strings.EqualFold(t.Name, to) {
-			match = &transitions[i]
-			break
-		}
-	}
-
+	transitionName := func(t models.Transition) string { return t.Name }
+	match := app.MatchByName(transitions, to, transitionName)
 	if match == nil {
-		names := make([]string, len(transitions))
-		for i, t := range transitions {
-			names[i] = t.Name
-		}
-		return fmt.Errorf("transition %q not found; available: %s", to, strings.Join(names, ", "))
+		return fmt.Errorf("transition %q not found; available: %s", to, strings.Join(app.Names(transitions, transitionName), ", "))
 	}
 
 	req := &models.TransitionRequest{
@@ -83,12 +72,7 @@ func runTransitions(cmd *cobra.Command, args []string) error {
 	}
 
 	if a.Output == "json" {
-		data, err := json.MarshalIndent(transitions, "", "  ")
-		if err != nil {
-			return err
-		}
-		fmt.Println(string(data))
-		return nil
+		return app.OutputJSON(transitions)
 	}
 
 	printTransitions(transitions)

--- a/cmd/issue/view.go
+++ b/cmd/issue/view.go
@@ -2,8 +2,6 @@ package issue
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 
 	"github.com/amplia/jira8/cmd/app"
 	"github.com/spf13/cobra"
@@ -33,12 +31,7 @@ func runView(cmd *cobra.Command, args []string) error {
 	}
 
 	if a.Output == "json" {
-		data, err := json.MarshalIndent(issue, "", "  ")
-		if err != nil {
-			return err
-		}
-		fmt.Println(string(data))
-		return nil
+		return app.OutputJSON(issue)
 	}
 
 	// Resolve Epic custom field IDs best-effort so view can render Epic Name /

--- a/cmd/issue/worklog_add.go
+++ b/cmd/issue/worklog_add.go
@@ -2,7 +2,6 @@ package issue
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/amplia/jira8/cmd/app"
@@ -60,12 +59,7 @@ func runWorklogAdd(cmd *cobra.Command, args []string) error {
 	}
 
 	if a.Output == "json" {
-		data, err := json.MarshalIndent(wl, "", "  ")
-		if err != nil {
-			return err
-		}
-		fmt.Println(string(data))
-		return nil
+		return app.OutputJSON(wl)
 	}
 
 	fmt.Printf("Worklog added to %s: %s (ID: %s)\n", key, wl.TimeSpent, wl.ID)

--- a/cmd/issue/worklog_list.go
+++ b/cmd/issue/worklog_list.go
@@ -2,7 +2,6 @@ package issue
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/amplia/jira8/cmd/app"
@@ -36,12 +35,7 @@ func runWorklogList(cmd *cobra.Command, args []string) error {
 	}
 
 	if a.Output == "json" {
-		data, err := json.MarshalIndent(worklogs, "", "  ")
-		if err != nil {
-			return err
-		}
-		fmt.Println(string(data))
-		return nil
+		return app.OutputJSON(worklogs)
 	}
 
 	if len(worklogs) == 0 {

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -469,13 +469,9 @@ func createIssueHandler(jc *client.Client) server.ToolHandlerFunc {
 		}
 
 		if assignee := req.GetString("assignee", ""); assignee != "" {
-			username := assignee
-			if strings.EqualFold(assignee, "me") {
-				user, err := jc.GetMyself(ctx)
-				if err != nil {
-					return mcp.NewToolResultError(fmt.Sprintf("resolving current user: %s", err)), nil
-				}
-				username = user.Name
+			username, err := jc.ResolveAssignee(ctx, assignee)
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
 			}
 			createReq.Fields.Assignee = &models.UserRef{Name: username}
 		}
@@ -549,13 +545,9 @@ func editIssueHandler(jc *client.Client) server.ToolHandlerFunc {
 			if assignee == "" {
 				fields["assignee"] = nil
 			} else {
-				username := assignee
-				if strings.EqualFold(assignee, "me") {
-					user, err := jc.GetMyself(ctx)
-					if err != nil {
-						return mcp.NewToolResultError(fmt.Sprintf("resolving current user: %s", err)), nil
-					}
-					username = user.Name
+				username, err := jc.ResolveAssignee(ctx, assignee)
+				if err != nil {
+					return mcp.NewToolResultError(err.Error()), nil
 				}
 				fields["assignee"] = models.UserRef{Name: username}
 			}
@@ -726,20 +718,10 @@ func transitionIssueHandler(jc *client.Client) server.ToolHandlerFunc {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
 
-		var match *models.Transition
-		for i, t := range transitions {
-			if strings.EqualFold(t.Name, transitionName) {
-				match = &transitions[i]
-				break
-			}
-		}
-
+		nameOf := func(t models.Transition) string { return t.Name }
+		match := app.MatchByName(transitions, transitionName, nameOf)
 		if match == nil {
-			names := make([]string, len(transitions))
-			for i, t := range transitions {
-				names[i] = t.Name
-			}
-			return mcp.NewToolResultError(fmt.Sprintf("transition %q not found; available: %s", transitionName, strings.Join(names, ", "))), nil
+			return mcp.NewToolResultError(fmt.Sprintf("transition %q not found; available: %s", transitionName, strings.Join(app.Names(transitions, nameOf), ", "))), nil
 		}
 
 		transReq := &models.TransitionRequest{
@@ -774,19 +756,10 @@ func linkIssuesHandler(jc *client.Client) server.ToolHandlerFunc {
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
-		var match *models.IssueLinkType
-		for i := range types {
-			if strings.EqualFold(types[i].Name, typeName) {
-				match = &types[i]
-				break
-			}
-		}
+		nameOf := func(t models.IssueLinkType) string { return t.Name }
+		match := app.MatchByName(types, typeName, nameOf)
 		if match == nil {
-			names := make([]string, len(types))
-			for i, t := range types {
-				names[i] = t.Name
-			}
-			return mcp.NewToolResultError(fmt.Sprintf("link type %q not found; available: %s", typeName, strings.Join(names, ", "))), nil
+			return mcp.NewToolResultError(fmt.Sprintf("link type %q not found; available: %s", typeName, strings.Join(app.Names(types, nameOf), ", "))), nil
 		}
 
 		linkReq := &models.IssueLinkRequest{
@@ -1056,13 +1029,9 @@ func createEpicHandler(jc *client.Client) server.ToolHandlerFunc {
 		}
 
 		if assignee := req.GetString("assignee", ""); assignee != "" {
-			username := assignee
-			if strings.EqualFold(assignee, "me") {
-				user, err := jc.GetMyself(ctx)
-				if err != nil {
-					return mcp.NewToolResultError(fmt.Sprintf("resolving current user: %s", err)), nil
-				}
-				username = user.Name
+			username, err := jc.ResolveAssignee(ctx, assignee)
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
 			}
 			createReq.Fields.Assignee = &models.UserRef{Name: username}
 		}
@@ -1111,13 +1080,9 @@ func editEpicHandler(jc *client.Client) server.ToolHandlerFunc {
 			if assignee == "" {
 				fields["assignee"] = nil
 			} else {
-				username := assignee
-				if strings.EqualFold(assignee, "me") {
-					user, err := jc.GetMyself(ctx)
-					if err != nil {
-						return mcp.NewToolResultError(fmt.Sprintf("resolving current user: %s", err)), nil
-					}
-					username = user.Name
+				username, err := jc.ResolveAssignee(ctx, assignee)
+				if err != nil {
+					return mcp.NewToolResultError(err.Error()), nil
 				}
 				fields["assignee"] = models.UserRef{Name: username}
 			}

--- a/cmd/mcp_prompts.go
+++ b/cmd/mcp_prompts.go
@@ -158,7 +158,7 @@ func epicBreakdownPromptHandler(jc *client.Client) server.PromptHandlerFunc {
 
 		var b strings.Builder
 		b.WriteString(summariseIssueForPrompt(epic))
-		b.WriteString(fmt.Sprintf("\n\nCurrent children (%d):\n", len(children)))
+		fmt.Fprintf(&b, "\n\nCurrent children (%d):\n", len(children))
 		if len(children) == 0 {
 			b.WriteString("  (none)\n")
 		}
@@ -171,7 +171,7 @@ func epicBreakdownPromptHandler(jc *client.Client) server.PromptHandlerFunc {
 			if c.Fields.IssueType != nil {
 				itype = c.Fields.IssueType.Name
 			}
-			b.WriteString(fmt.Sprintf("  - %s [%s, %s] %s\n", c.Key, itype, status, c.Fields.Summary))
+			fmt.Fprintf(&b, "  - %s [%s, %s] %s\n", c.Key, itype, status, c.Fields.Summary)
 		}
 
 		instructions := strings.Join([]string{
@@ -208,7 +208,7 @@ func summariseCommentsPromptHandler(jc *client.Client) server.PromptHandlerFunc 
 
 		var b strings.Builder
 		b.WriteString(summariseIssueForPrompt(issue))
-		b.WriteString(fmt.Sprintf("\nComments (%d):\n", len(comments)))
+		fmt.Fprintf(&b, "\nComments (%d):\n", len(comments))
 		if len(comments) == 0 {
 			b.WriteString("  (none)\n")
 		}
@@ -221,7 +221,7 @@ func summariseCommentsPromptHandler(jc *client.Client) server.PromptHandlerFunc 
 				}
 			}
 			body := strings.ReplaceAll(c.Body, "\n", " ")
-			b.WriteString(fmt.Sprintf("  - [%s] %s — %s\n", c.Created, author, body))
+			fmt.Fprintf(&b, "  - [%s] %s — %s\n", c.Created, author, body)
 		}
 
 		instructions := strings.Join([]string{
@@ -246,32 +246,32 @@ func summariseCommentsPromptHandler(jc *client.Client) server.PromptHandlerFunc 
 func summariseIssueForPrompt(i *models.Issue) string {
 	f := i.Fields
 	var b strings.Builder
-	b.WriteString(fmt.Sprintf("Issue %s — %s\n", i.Key, f.Summary))
+	fmt.Fprintf(&b, "Issue %s — %s\n", i.Key, f.Summary)
 	if f.IssueType != nil {
-		b.WriteString(fmt.Sprintf("  Type:     %s\n", f.IssueType.Name))
+		fmt.Fprintf(&b, "  Type:     %s\n", f.IssueType.Name)
 	}
 	if f.Status != nil {
-		b.WriteString(fmt.Sprintf("  Status:   %s\n", f.Status.Name))
+		fmt.Fprintf(&b, "  Status:   %s\n", f.Status.Name)
 	}
 	if f.Priority != nil {
-		b.WriteString(fmt.Sprintf("  Priority: %s\n", f.Priority.Name))
+		fmt.Fprintf(&b, "  Priority: %s\n", f.Priority.Name)
 	}
 	if f.Assignee != nil {
 		name := f.Assignee.DisplayName
 		if name == "" {
 			name = f.Assignee.Name
 		}
-		b.WriteString(fmt.Sprintf("  Assignee: %s\n", name))
+		fmt.Fprintf(&b, "  Assignee: %s\n", name)
 	}
 	if f.Reporter != nil {
 		name := f.Reporter.DisplayName
 		if name == "" {
 			name = f.Reporter.Name
 		}
-		b.WriteString(fmt.Sprintf("  Reporter: %s\n", name))
+		fmt.Fprintf(&b, "  Reporter: %s\n", name)
 	}
 	if len(f.Labels) > 0 {
-		b.WriteString(fmt.Sprintf("  Labels:   %s\n", strings.Join(f.Labels, ", ")))
+		fmt.Fprintf(&b, "  Labels:   %s\n", strings.Join(f.Labels, ", "))
 	}
 	if f.Description != "" {
 		b.WriteString("Description:\n")

--- a/cmd/project/priorities.go
+++ b/cmd/project/priorities.go
@@ -2,7 +2,6 @@ package project
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/amplia/jira8/cmd/app"
@@ -25,12 +24,7 @@ func runPriorities(cmd *cobra.Command, args []string) error {
 	}
 
 	if a.Output == "json" {
-		data, err := json.MarshalIndent(priorities, "", "  ")
-		if err != nil {
-			return err
-		}
-		fmt.Println(string(data))
-		return nil
+		return app.OutputJSON(priorities)
 	}
 
 	fmt.Println("Priorities:")

--- a/cmd/project/statuses.go
+++ b/cmd/project/statuses.go
@@ -2,7 +2,6 @@ package project
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -35,12 +34,7 @@ func runStatuses(cmd *cobra.Command, args []string) error {
 	}
 
 	if a.Output == "json" {
-		data, err := json.MarshalIndent(result, "", "  ")
-		if err != nil {
-			return err
-		}
-		fmt.Println(string(data))
-		return nil
+		return app.OutputJSON(result)
 	}
 
 	fmt.Printf("Statuses for %s:\n\n", project)

--- a/cmd/project/types.go
+++ b/cmd/project/types.go
@@ -2,7 +2,6 @@ package project
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/amplia/jira8/cmd/app"
@@ -34,12 +33,7 @@ func runTypes(cmd *cobra.Command, args []string) error {
 	}
 
 	if a.Output == "json" {
-		data, err := json.MarshalIndent(meta.IssueTypes, "", "  ")
-		if err != nil {
-			return err
-		}
-		fmt.Println(string(data))
-		return nil
+		return app.OutputJSON(meta.IssueTypes)
 	}
 
 	fmt.Printf("Issue types for %s:\n\n", project)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -71,7 +71,7 @@ func init() {
 // Execute runs the root command.
 func Execute() error {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintf(rootCmd.ErrOrStderr(), "Error: %s\n", err)
+		_, _ = fmt.Fprintf(rootCmd.ErrOrStderr(), "Error: %s\n", err)
 		return err
 	}
 	return nil

--- a/internal/client/jira.go
+++ b/internal/client/jira.go
@@ -38,9 +38,7 @@ type APIError struct {
 
 func (e *APIError) Error() string {
 	var parts []string
-	for _, m := range e.Messages {
-		parts = append(parts, m)
-	}
+	parts = append(parts, e.Messages...)
 	for field, msg := range e.Errors {
 		parts = append(parts, fmt.Sprintf("%s: %s", field, msg))
 	}
@@ -48,6 +46,19 @@ func (e *APIError) Error() string {
 		return fmt.Sprintf("Jira API error (HTTP %d)", e.StatusCode)
 	}
 	return fmt.Sprintf("Jira API error (HTTP %d): %s", e.StatusCode, strings.Join(parts, "; "))
+}
+
+// parseAPIError builds an APIError from a Jira error response body. A body that
+// is not the expected JiraError shape leaves Messages/Errors empty, so the
+// error still carries the HTTP status code.
+func parseAPIError(statusCode int, respBody []byte) *APIError {
+	apiErr := &APIError{StatusCode: statusCode}
+	var jiraErr models.JiraError
+	if json.Unmarshal(respBody, &jiraErr) == nil {
+		apiErr.Messages = jiraErr.ErrorMessages
+		apiErr.Errors = jiraErr.Errors
+	}
+	return apiErr
 }
 
 // Client is the Jira REST API client.
@@ -80,18 +91,24 @@ func New(cfg *config.Config) *Client {
 
 // do executes an HTTP request against the Jira API with auth, retries, and error handling.
 func (c *Client) do(ctx context.Context, method, path string, body any) ([]byte, error) {
-	var bodyReader io.Reader
+	var bodyBytes []byte
 	if body != nil {
 		data, err := json.Marshal(body)
 		if err != nil {
 			return nil, fmt.Errorf("marshaling request body: %w", err)
 		}
-		bodyReader = bytes.NewReader(data)
+		bodyBytes = data
 	}
 
 	fullURL := c.baseURL + apiBasePath + path
 
 	for attempt := range maxRetries {
+		// Recreate the reader on every attempt; a retried request needs a fresh
+		// reader because the previous attempt consumed the previous one.
+		var bodyReader io.Reader
+		if bodyBytes != nil {
+			bodyReader = bytes.NewReader(bodyBytes)
+		}
 		req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
 		if err != nil {
 			return nil, fmt.Errorf("creating request: %w", err)
@@ -106,7 +123,7 @@ func (c *Client) do(ctx context.Context, method, path string, body any) ([]byte,
 		}
 
 		respBody, err := io.ReadAll(resp.Body)
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		if err != nil {
 			return nil, fmt.Errorf("reading response body: %w", err)
 		}
@@ -119,22 +136,11 @@ func (c *Client) do(ctx context.Context, method, path string, body any) ([]byte,
 				}
 			}
 			time.Sleep(wait)
-			// Reset body reader for retry
-			if body != nil {
-				data, _ := json.Marshal(body)
-				bodyReader = bytes.NewReader(data)
-			}
 			continue
 		}
 
 		if resp.StatusCode >= 400 {
-			apiErr := &APIError{StatusCode: resp.StatusCode}
-			var jiraErr models.JiraError
-			if json.Unmarshal(respBody, &jiraErr) == nil {
-				apiErr.Messages = jiraErr.ErrorMessages
-				apiErr.Errors = jiraErr.Errors
-			}
-			return nil, apiErr
+			return nil, parseAPIError(resp.StatusCode, respBody)
 		}
 
 		return respBody, nil
@@ -412,6 +418,21 @@ func (c *Client) GetMyself(ctx context.Context) (*models.User, error) {
 	return &user, nil
 }
 
+// ResolveAssignee maps the "me" alias (case-insensitive) to the authenticated
+// user's username via GetMyself; any other value is returned unchanged. Callers
+// are responsible for the empty-string case (skip the field, or clear it).
+// Shared by the CLI create/edit commands and the equivalent MCP tools.
+func (c *Client) ResolveAssignee(ctx context.Context, assignee string) (string, error) {
+	if !strings.EqualFold(assignee, "me") {
+		return assignee, nil
+	}
+	user, err := c.GetMyself(ctx)
+	if err != nil {
+		return "", fmt.Errorf("resolving current user: %w", err)
+	}
+	return user.Name, nil
+}
+
 // GetProjectStatuses returns issue types and their statuses for a project.
 func (c *Client) GetProjectStatuses(ctx context.Context, projectKey string) ([]models.IssueTypeWithStatuses, error) {
 	data, err := c.do(ctx, http.MethodGet, "/project/"+url.PathEscape(projectKey)+"/statuses", nil)
@@ -458,7 +479,7 @@ func (c *Client) GetPriorities(ctx context.Context) ([]models.Priority, error) {
 	return result, nil
 }
 
-// JQLFilters groups the individual filter inputs accepted by BuildJQL.
+// JQLFilters groups the individual filter inputs accepted by BuildJQLWith.
 // Fields are optional — empty values are skipped.
 type JQLFilters struct {
 	Project  string
@@ -466,13 +487,6 @@ type JQLFilters struct {
 	Assignee string
 	Epic     string // issue key whose Epic Link equals this value
 	Type     string // issue type name (e.g. "Epic", "Story")
-}
-
-// BuildJQL constructs a JQL query from the provided filters.
-// Use BuildJQLWith for the full filter set; this variant is kept for compatibility
-// and covers project/status/assignee only.
-func BuildJQL(project, status, assignee string) string {
-	return BuildJQLWith(JQLFilters{Project: project, Status: status, Assignee: assignee})
 }
 
 // BuildJQLWith constructs a JQL query from a JQLFilters struct.

--- a/internal/client/jira_test.go
+++ b/internal/client/jira_test.go
@@ -59,16 +59,6 @@ func TestBuildJQLWith(t *testing.T) {
 	}
 }
 
-// TestBuildJQL_Compat verifies the legacy 3-arg wrapper still builds the same JQL
-// as the full filter struct for equivalent inputs.
-func TestBuildJQL_Compat(t *testing.T) {
-	got := BuildJQL("ESA", "Done", "alice")
-	want := BuildJQLWith(JQLFilters{Project: "ESA", Status: "Done", Assignee: "alice"})
-	if got != want {
-		t.Errorf("BuildJQL vs BuildJQLWith mismatch: %q vs %q", got, want)
-	}
-}
-
 func TestResolveEpicFields(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !strings.HasSuffix(r.URL.Path, "/rest/api/2/field") {

--- a/internal/client/multipart.go
+++ b/internal/client/multipart.go
@@ -2,15 +2,12 @@ package client
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"mime/multipart"
 	"net/http"
 	"os"
 	"path/filepath"
-
-	"github.com/amplia/jira8/internal/models"
 )
 
 // doMultipartUpload posts one or more files to a Jira multipart endpoint
@@ -88,7 +85,7 @@ func (c *Client) doMultipartUpload(ctx context.Context, path string, files []str
 	if err != nil {
 		return nil, fmt.Errorf("executing request: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -96,13 +93,7 @@ func (c *Client) doMultipartUpload(ctx context.Context, path string, files []str
 	}
 
 	if resp.StatusCode >= 400 {
-		apiErr := &APIError{StatusCode: resp.StatusCode}
-		var jiraErr models.JiraError
-		if json.Unmarshal(respBody, &jiraErr) == nil {
-			apiErr.Messages = jiraErr.ErrorMessages
-			apiErr.Errors = jiraErr.Errors
-		}
-		return nil, apiErr
+		return nil, parseAPIError(resp.StatusCode, respBody)
 	}
 
 	return respBody, nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,7 +10,6 @@ import (
 // Config holds the Jira CLI configuration.
 type Config struct {
 	URL      string `mapstructure:"url"`
-	Email    string `mapstructure:"email"`
 	Token    string `mapstructure:"token"`
 	User     string `mapstructure:"user"`
 	Password string `mapstructure:"password"`
@@ -35,7 +34,6 @@ func Load(configFile string) (*Config, error) {
 	viper.SetDefault("project", "ESA")
 
 	_ = viper.BindEnv("url", "JIRA_URL")
-	_ = viper.BindEnv("email", "JIRA_EMAIL")
 	_ = viper.BindEnv("token", "JIRA_TOKEN")
 	_ = viper.BindEnv("user", "JIRA_USER")
 	_ = viper.BindEnv("password", "JIRA_PASSWORD")

--- a/internal/markup/markup.go
+++ b/internal/markup/markup.go
@@ -290,7 +290,7 @@ func WikiToMarkdown(s string) string {
 	inQuote := false
 	inTable := false
 
-	for i := 0; i < len(lines); i++ {
+	for i := range lines {
 		line := lines[i]
 
 		if inFence {

--- a/internal/markup/markup.go
+++ b/internal/markup/markup.go
@@ -132,10 +132,10 @@ func indentDepth(indent string) int {
 }
 
 var (
-	fenceLineRe   = regexp.MustCompile("^```([A-Za-z0-9_+\\-]*)\\s*$")
-	headingRe     = regexp.MustCompile(`^(#{1,6})\s+(.*)$`)
-	bulletListRe  = regexp.MustCompile(`^([ \t]*)[-*+]\s+(.*)$`)
-	orderedListRe = regexp.MustCompile(`^([ \t]*)\d+\.\s+(.*)$`)
+	fenceLineRe          = regexp.MustCompile("^```([A-Za-z0-9_+\\-]*)\\s*$")
+	headingRe            = regexp.MustCompile(`^(#{1,6})\s+(.*)$`)
+	bulletListRe         = regexp.MustCompile(`^([ \t]*)[-*+]\s+(.*)$`)
+	orderedListRe        = regexp.MustCompile(`^([ \t]*)\d+\.\s+(.*)$`)
 	tableSeparatorCellRe = regexp.MustCompile(`^:?-{3,}:?$`)
 
 	inlineCodeRe  = regexp.MustCompile("`([^`\n]+)`")
@@ -185,12 +185,12 @@ func transformInline(s string) string {
 
 	s = boldPlaceholderRe.ReplaceAllStringFunc(s, func(m string) string {
 		var idx int
-		fmt.Sscanf(m, "\x00B%d\x00", &idx)
+		_, _ = fmt.Sscanf(m, "\x00B%d\x00", &idx)
 		return "*" + bolds[idx] + "*"
 	})
 	s = codePlaceholderRe.ReplaceAllStringFunc(s, func(m string) string {
 		var idx int
-		fmt.Sscanf(m, "\x00C%d\x00", &idx)
+		_, _ = fmt.Sscanf(m, "\x00C%d\x00", &idx)
 		return "{{" + codes[idx] + "}}"
 	})
 
@@ -252,15 +252,22 @@ func isTableSeparator(s string) bool {
 	return true
 }
 
-func splitTableRow(s string) []string {
+// splitTableCells splits a table row on the given delimiter, dropping the
+// leading/trailing delimiter and trimming each cell. It backs both the
+// Markdown ("|") and Wiki header ("||") splitters.
+func splitTableCells(s, delim string) []string {
 	t := strings.TrimSpace(s)
-	t = strings.TrimPrefix(t, "|")
-	t = strings.TrimSuffix(t, "|")
-	parts := strings.Split(t, "|")
+	t = strings.TrimPrefix(t, delim)
+	t = strings.TrimSuffix(t, delim)
+	parts := strings.Split(t, delim)
 	for i, p := range parts {
 		parts[i] = strings.TrimSpace(p)
 	}
 	return parts
+}
+
+func splitTableRow(s string) []string {
+	return splitTableCells(s, "|")
 }
 
 // WikiToMarkdown converts a Jira Server 8 Wiki Markup string into Markdown.
@@ -432,12 +439,12 @@ func transformInlineWiki(s string) string {
 
 	s = wikiBoldPlaceholderRe.ReplaceAllStringFunc(s, func(m string) string {
 		var idx int
-		fmt.Sscanf(m, "\x00X%d\x00", &idx)
+		_, _ = fmt.Sscanf(m, "\x00X%d\x00", &idx)
 		return "**" + bolds[idx] + "**"
 	})
 	s = wikiCodePlaceholderRe.ReplaceAllStringFunc(s, func(m string) string {
 		var idx int
-		fmt.Sscanf(m, "\x00W%d\x00", &idx)
+		_, _ = fmt.Sscanf(m, "\x00W%d\x00", &idx)
 		return "`" + codes[idx] + "`"
 	})
 
@@ -461,12 +468,5 @@ func isWikiTableRow(s string) bool {
 }
 
 func splitWikiTableHeader(s string) []string {
-	t := strings.TrimSpace(s)
-	t = strings.TrimPrefix(t, "||")
-	t = strings.TrimSuffix(t, "||")
-	parts := strings.Split(t, "||")
-	for i, p := range parts {
-		parts[i] = strings.TrimSpace(p)
-	}
-	return parts
+	return splitTableCells(s, "||")
 }

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -322,8 +322,8 @@ type CreateIssueResponse struct {
 	Self string `json:"self"`
 }
 
-// ProjectStatuses represents the response from GET /rest/api/2/project/{key}/statuses.
-// Returns issue types with their available statuses.
+// IssueTypeWithStatuses is a single issue type with its available statuses,
+// one element of the response from GET /rest/api/2/project/{key}/statuses.
 type IssueTypeWithStatuses struct {
 	Name     string   `json:"name"`
 	ID       string   `json:"id"`


### PR DESCRIPTION
## What

Internal quality sweep after #53. **No behavior change, no new dependencies, no API surface change** — every existing test still passes, plus `golangci-lint`, `deadcode` and `gopls modernize` are now clean.

Net **−201 lines** across the codebase (132+ / 333−).

## Changes (by commit)

1. **refactor(client)** — extract `parseAPIError` (shared by `do()` + multipart upload); add `client.ResolveAssignee` to resolve the `"me"` alias in one place (was duplicated ~8×); marshal the request body once and recreate the reader per retry attempt; remove the dead `BuildJQL` 3-arg wrapper (+ its test) and the unused `Config.Email` field.
2. **refactor(markup)** — fold `splitTableRow`/`splitWikiTableHeader` into `splitTableCells(delim)`; fix the `IssueTypeWithStatuses` doc comment; check discarded `Sscanf` returns.
3. **refactor(cmd)** — `app.OutputJSON` replaces the JSON-output boilerplate (~17 sites); generic `app.MatchByName`/`app.Names` back the transition & link-type name lookups in both CLI and MCP; adopt `client.ResolveAssignee` across CLI create/edit, epic create/edit and the MCP tools.
4. **style(cmd)** — satisfy `golangci-lint` (errcheck, QF1012).
5. **style** — apply `gopls modernize` (`strings.SplitSeq`, range-over-int).

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` — green.
- `golangci-lint run ./...` — 0 issues (was 10).
- `deadcode ./...` — no reachable dead code.
- `gofmt` — clean.

CLI↔MCP parity preserved: the shared helpers are used identically on both surfaces.