### PR TITLE
chore: track .mcp.json; ignore local dev files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@ jira8
 .jira.yaml
 .env
 .claude/
+
+# Local developer environment (not part of the project)
+.task/
+.tmuxp.yaml
+jira8-improvements.md

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "jira8": {
+      "command": "./jira8",
+      "args": ["mcp", "serve"]
+    }
+  }
+}


### PR DESCRIPTION
Repo hygiene — leaves a clean working tree.

- **Track `.mcp.json`**: project-level MCP config (`./jira8 mcp serve`, relative path, no secrets) so Claude Code / Gemini CLI / LM Studio auto-discover the jira8 MCP server when the repo is opened.
- **gitignore** `.task/` (go-task cache), `.tmuxp.yaml` (personal tmux session) and `jira8-improvements.md` (local feedback doc) — all local-only.

No code change, no release needed.