### PR TITLE
feat(issue): rank issues within a board column

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,31 @@ jira8 issue transitions MYPROJ-123               # list available transitions
 jira8 issue transition MYPROJ-123 --to "Done"    # perform transition
 ```
 
+### Ranking (kanban order)
+
+Ranking changes the **vertical** position of an issue inside a board column. It
+never changes the status — moving an issue to another column is a transition.
+
+```bash
+jira8 issue rank MYPROJ-123 --top                       # first position of its column
+jira8 issue rank MYPROJ-123 --bottom                    # last position of its column
+jira8 issue rank MYPROJ-123 --before MYPROJ-99          # immediately above another issue
+jira8 issue rank MYPROJ-123 --after MYPROJ-99           # immediately below another issue
+jira8 issue rank MYPROJ-1 MYPROJ-2 --top --board 110    # a block, keeping relative order
+```
+
+`--top` / `--bottom` work out which column the issue currently sits in (from the
+board's status mapping) and move it to that column's edge. When the project has
+more than one board, pass `--board` with an ID or name; without it the error lists
+the candidates:
+
+```
+Error: project MYPROJ has 5 boards, specify one: "Team Kanban" (110, kanban), ...
+```
+
+Up to 50 issues can be ranked in a single call. If the issues already occupy the
+requested edge, the command reports it and sends nothing.
+
 ### Links
 
 ```bash
@@ -233,6 +258,7 @@ jira8 mcp serve
 | `jira_edit_issue` | Edit an existing issue (supports `epic_name`, `epic_link`, `attachments[]`) |
 | `jira_transition_issue` | Transition an issue |
 | `jira_list_transitions` | List available transitions |
+| `jira_rank_issue` | Reorder issues in a board column (`top`, `bottom`, `before`, `after`) |
 | `jira_add_comment` | Add a comment |
 | `jira_list_comments` | List comments |
 | `jira_edit_comment` | Edit an existing comment |

--- a/README.md
+++ b/README.md
@@ -177,7 +177,13 @@ Error: project MYPROJ has 5 boards, specify one: "Team Kanban" (110, kanban), ..
 ```
 
 Up to 50 issues can be ranked in a single call. If the issues already occupy the
-requested edge, the command reports it and sends nothing.
+requested edge, the command reports it and sends nothing. Ranking an issue that is
+already at the top is a no-change operation, not an error.
+
+Ranking needs Jira Software (the Agile/Greenhopper plugin) — it uses the Agile API
+(`/rest/agile/1.0`), unlike every other command, which lives on `/rest/api/2`. The
+rank field is discovered per board, falling back to the instance-wide LexoRank
+field, so no custom field ID has to be configured.
 
 ### Links
 
@@ -390,5 +396,6 @@ Every capability exposed via Resources or Prompts is also reachable via Tools, s
 ## Target
 
 - Jira Server 8.7.1
-- REST API v2
+- REST API v2, plus the Agile API (`/rest/agile/1.0`) for board ranking
 - Authentication: Basic Auth (user:password) or Personal Access Token (Bearer)
+- Epic and ranking commands additionally require Jira Software (Agile/Greenhopper)

--- a/cmd/issue/issue.go
+++ b/cmd/issue/issue.go
@@ -16,6 +16,7 @@ func init() {
 	IssueCmd.AddCommand(editCmd)
 	IssueCmd.AddCommand(transitionCmd)
 	IssueCmd.AddCommand(transitionsCmd)
+	IssueCmd.AddCommand(rankCmd)
 	IssueCmd.AddCommand(worklogAddCmd)
 	IssueCmd.AddCommand(worklogListCmd)
 	IssueCmd.AddCommand(worklogDeleteCmd)

--- a/cmd/issue/rank.go
+++ b/cmd/issue/rank.go
@@ -1,0 +1,103 @@
+package issue
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/amplia/jira8/cmd/app"
+	"github.com/amplia/jira8/internal/client"
+	"github.com/spf13/cobra"
+)
+
+var rankCmd = &cobra.Command{
+	Use:   "rank ISSUE-KEY... (--top | --bottom | --before KEY | --after KEY)",
+	Short: "Reorder issues inside a board column",
+	Long: "Change the vertical position of one or more issues on an Agile board.\n\n" +
+		"Ranking moves an issue up or down within its column; it never changes the " +
+		"issue's status. To move an issue to a different column use 'issue transition'.\n\n" +
+		"--top and --bottom resolve the issue's own column on the board and move it to " +
+		"the first or last position of that column. When the project has more than one " +
+		"board, pass --board with an ID or name (the error lists the candidates).\n\n" +
+		"Several keys can be ranked at once (up to 50); they keep their relative order.",
+	Example: "  jira8 issue rank PHO-5050 --top\n" +
+		"  jira8 issue rank PHO-5050 --bottom --board \"Phoenix Kanban\"\n" +
+		"  jira8 issue rank PHO-5050 --before PHO-4941\n" +
+		"  jira8 issue rank PHO-5050 PHO-5021 --top --board 110",
+	Args: cobra.MinimumNArgs(1),
+	RunE: runRank,
+}
+
+func init() {
+	rankCmd.Flags().Bool("top", false, "Move to the first position of the issue's column")
+	rankCmd.Flags().Bool("bottom", false, "Move to the last position of the issue's column")
+	rankCmd.Flags().String("before", "", "Move immediately above this issue key")
+	rankCmd.Flags().String("after", "", "Move immediately below this issue key")
+	rankCmd.Flags().String("board", "", "Board ID or name; only needed by --top/--bottom when the project has several boards")
+
+	rankCmd.MarkFlagsMutuallyExclusive("top", "bottom", "before", "after")
+	rankCmd.MarkFlagsOneRequired("top", "bottom", "before", "after")
+}
+
+func runRank(cmd *cobra.Command, args []string) error {
+	a := app.Get()
+	top, _ := cmd.Flags().GetBool("top")
+	bottom, _ := cmd.Flags().GetBool("bottom")
+	before, _ := cmd.Flags().GetString("before")
+	after, _ := cmd.Flags().GetString("after")
+	board, _ := cmd.Flags().GetString("board")
+
+	req := client.RankRequest{Keys: args, Board: board}
+	switch {
+	case top:
+		req.Position = client.RankTop
+	case bottom:
+		req.Position = client.RankBottom
+	case before != "":
+		req.Position, req.Anchor = client.RankBefore, before
+	case after != "":
+		req.Position, req.Anchor = client.RankAfter, after
+	}
+
+	result, err := a.Client.RankIssuesRelative(context.Background(), req)
+	if err != nil {
+		return err
+	}
+
+	if a.Output == "json" {
+		return app.OutputJSON(result)
+	}
+
+	fmt.Println(describeRank(result))
+	return nil
+}
+
+// describeRank renders a human-readable summary of a completed rank operation,
+// including the anchor that was resolved so the user can verify the move.
+func describeRank(r *client.RankResult) string {
+	issues := strings.Join(r.Issues, ", ")
+	edge := "top"
+	if r.Position == client.RankBottom {
+		edge = "bottom"
+	}
+
+	switch r.Position {
+	case client.RankTop, client.RankBottom:
+		where := fmt.Sprintf("the %s of %q", edge, r.Column)
+		if r.Board != nil {
+			where += fmt.Sprintf(" (board %q)", r.Board.Name)
+		}
+		if r.NoOp {
+			return fmt.Sprintf("%s already at %s; nothing to do", issues, where)
+		}
+		relation := "above"
+		if r.Position == client.RankBottom {
+			relation = "below"
+		}
+		return fmt.Sprintf("Ranked %s to %s, %s %s", issues, where, relation, r.Anchor)
+	case client.RankBefore:
+		return fmt.Sprintf("Ranked %s above %s", issues, r.Anchor)
+	default:
+		return fmt.Sprintf("Ranked %s below %s", issues, r.Anchor)
+	}
+}

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -131,6 +131,27 @@ func runMCPServe(cmd *cobra.Command, args []string) error {
 	)
 
 	s.AddTool(
+		mcp.NewTool("jira_rank_issue",
+			mcp.WithDescription("Reorder issues inside an Agile board column (kanban rank). "+
+				"Ranking changes only the vertical position of an issue within its column — it does NOT change its status; "+
+				"use jira_transition_issue to move an issue to another column. "+
+				"Exactly one of top, bottom, before or after must be given. "+
+				"top/bottom resolve the issue's own column and move it to the first/last position of that column."),
+			mcp.WithArray("keys",
+				mcp.WithStringItems(),
+				mcp.Description("Issue keys to move, up to 50, keeping their relative order (e.g. [\"ESA-123\"]). A single 'key' string is also accepted."),
+			),
+			mcp.WithString("key", mcp.Description("Single issue key, convenience alternative to 'keys' (e.g. ESA-123)")),
+			mcp.WithBoolean("top", mcp.Description("Move to the first position of the issue's column")),
+			mcp.WithBoolean("bottom", mcp.Description("Move to the last position of the issue's column")),
+			mcp.WithString("before", mcp.Description("Move immediately above this issue key")),
+			mcp.WithString("after", mcp.Description("Move immediately below this issue key")),
+			mcp.WithString("board", mcp.Description("Board ID or name; only needed by top/bottom when the issue's project has several boards. The error message lists the candidates.")),
+		),
+		rankIssueHandler(jc),
+	)
+
+	s.AddTool(
 		mcp.NewTool("jira_link_issues",
 			mcp.WithDescription("Link two Jira issues (e.g. Relates, Blocks, Duplicate). The type must be one of the names returned by jira_list_link_types; defaults to Relates."),
 			mcp.WithString("outward", mcp.Required(), mcp.Description("Outward issue key — subject of the relation, e.g. the one that 'blocks' (e.g. ESA-207)")),
@@ -993,6 +1014,66 @@ func listTransitionsHandler(jc *client.Client) server.ToolHandlerFunc {
 		}
 
 		return mcp.NewToolResultText(toJSON(transitions)), nil
+	}
+}
+
+// rankIssueHandler reorders issues within a board column. Mirrors
+// `jira8 issue rank`: accepts top/bottom (resolve the issue's own column and
+// move it to that edge) or before/after (explicit anchor issue). Returns the
+// resolved anchor, board and column so the agent can report what happened, and
+// reports noop:true when the issues already sat at the requested edge.
+func rankIssueHandler(jc *client.Client) server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		keys := getStringArray(req, "keys")
+		if len(keys) == 0 {
+			if key := req.GetString("key", ""); key != "" {
+				keys = []string{key}
+			}
+		}
+		if len(keys) == 0 {
+			return mcp.NewToolResultError("no issues given: pass 'keys' (array of issue keys) or 'key' (single issue key)"), nil
+		}
+
+		top := req.GetBool("top", false)
+		bottom := req.GetBool("bottom", false)
+		before := req.GetString("before", "")
+		after := req.GetString("after", "")
+
+		// Reject ambiguity instead of silently picking one: a wrong guess here
+		// moves real issues on someone's board.
+		var given []string
+		for _, opt := range []struct {
+			name string
+			set  bool
+		}{{"top", top}, {"bottom", bottom}, {"before", before != ""}, {"after", after != ""}} {
+			if opt.set {
+				given = append(given, opt.name)
+			}
+		}
+		if len(given) != 1 {
+			return mcp.NewToolResultError(fmt.Sprintf(
+				"exactly one of top, bottom, before or after is required (got %d: %s)",
+				len(given), strings.Join(given, ", "))), nil
+		}
+
+		rr := client.RankRequest{Keys: keys, Board: req.GetString("board", "")}
+		switch {
+		case top:
+			rr.Position = client.RankTop
+		case bottom:
+			rr.Position = client.RankBottom
+		case before != "":
+			rr.Position, rr.Anchor = client.RankBefore, before
+		default:
+			rr.Position, rr.Anchor = client.RankAfter, after
+		}
+
+		result, err := jc.RankIssuesRelative(ctx, rr)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		return mcp.NewToolResultText(toJSON(result)), nil
 	}
 }
 

--- a/internal/client/jira.go
+++ b/internal/client/jira.go
@@ -21,12 +21,20 @@ const (
 	maxRetries  = 3
 	pageSize    = 50
 	apiBasePath = "/rest/api/2"
+	// agileBasePath is the Jira Software (Greenhopper) REST API. Boards, columns
+	// and issue ranking live here, not under /rest/api/2. The legacy
+	// /rest/greenhopper/1.0 endpoints are gone in Jira Server 8.
+	agileBasePath = "/rest/agile/1.0"
 
 	// Jira Server 8 schema identifiers for Greenhopper (Agile) custom fields.
 	// These are stable across instances; the numeric customfield_XXXXX IDs are NOT,
 	// which is why we resolve them dynamically via GET /field.
 	SchemaEpicName = "com.pyxis.greenhopper.jira:gh-epic-label"
 	SchemaEpicLink = "com.pyxis.greenhopper.jira:gh-epic-link"
+	// SchemaRank identifies the LexoRank field that drives the vertical order of
+	// board columns. Do not confuse it with "gh-global-rank", the obsolete
+	// pre-LexoRank field that some instances still expose.
+	SchemaRank = "com.pyxis.greenhopper.jira:gh-lexo-rank"
 )
 
 // APIError represents a Jira API error with status code and messages.
@@ -89,8 +97,20 @@ func New(cfg *config.Config) *Client {
 	}
 }
 
-// do executes an HTTP request against the Jira API with auth, retries, and error handling.
+// do executes an HTTP request against the Jira REST API v2 (/rest/api/2).
 func (c *Client) do(ctx context.Context, method, path string, body any) ([]byte, error) {
+	return c.doAt(ctx, method, apiBasePath+path, body)
+}
+
+// doAgile executes an HTTP request against the Jira Software Agile API
+// (/rest/agile/1.0), used for boards and issue ranking.
+func (c *Client) doAgile(ctx context.Context, method, path string, body any) ([]byte, error) {
+	return c.doAt(ctx, method, agileBasePath+path, body)
+}
+
+// doAt executes an HTTP request against an absolute API path (base included)
+// with auth, retries, and error handling.
+func (c *Client) doAt(ctx context.Context, method, apiPath string, body any) ([]byte, error) {
 	var bodyBytes []byte
 	if body != nil {
 		data, err := json.Marshal(body)
@@ -100,7 +120,7 @@ func (c *Client) do(ctx context.Context, method, path string, body any) ([]byte,
 		bodyBytes = data
 	}
 
-	fullURL := c.baseURL + apiBasePath + path
+	fullURL := c.baseURL + apiPath
 
 	for attempt := range maxRetries {
 		// Recreate the reader on every attempt; a retried request needs a fresh
@@ -561,4 +581,29 @@ func (c *Client) ResolveEpicFields(ctx context.Context) (epicNameID, epicLinkID 
 		return "", "", fmt.Errorf("epic fields not found on this Jira instance (Epic Name: %q, Epic Link: %q); is the Agile/Greenhopper plugin installed?", epicNameID, epicLinkID)
 	}
 	return epicNameID, epicLinkID, nil
+}
+
+// ResolveRankField returns the numeric ID of the LexoRank custom field on this
+// instance (e.g. 10200 for "customfield_10200"), matched on SchemaRank. Ranking
+// needs the bare number, both for the rank API payload and for JQL "cf[10200]"
+// ordering clauses. Used as a fallback when a board's configuration does not
+// report ranking.rankCustomFieldId.
+func (c *Client) ResolveRankField(ctx context.Context) (int, error) {
+	fields, err := c.GetFields(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	for _, f := range fields {
+		if f.Schema == nil || f.Schema.Custom != SchemaRank {
+			continue
+		}
+		id, err := strconv.Atoi(strings.TrimPrefix(f.ID, "customfield_"))
+		if err != nil {
+			return 0, fmt.Errorf("unexpected rank field ID %q: %w", f.ID, err)
+		}
+		return id, nil
+	}
+
+	return 0, fmt.Errorf("rank field not found on this Jira instance (schema %s); is Jira Software (Agile) installed?", SchemaRank)
 }

--- a/internal/client/rank.go
+++ b/internal/client/rank.go
@@ -1,0 +1,345 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/amplia/jira8/internal/models"
+)
+
+// maxRankIssues is the number of issues Jira accepts in a single rank call.
+const maxRankIssues = 50
+
+// RankPosition is where the moved issues should end up.
+type RankPosition string
+
+const (
+	// RankTop moves the issues to the first position of their own board column.
+	RankTop RankPosition = "top"
+	// RankBottom moves the issues to the last position of their own board column.
+	RankBottom RankPosition = "bottom"
+	// RankBefore moves the issues immediately above an explicit anchor issue.
+	RankBefore RankPosition = "before"
+	// RankAfter moves the issues immediately below an explicit anchor issue.
+	RankAfter RankPosition = "after"
+)
+
+// RankRequest describes a ranking operation. Ranking changes only the vertical
+// order of a board column; it never changes an issue's status (that is what a
+// transition does).
+type RankRequest struct {
+	// Keys are the issues to move, at most maxRankIssues. They keep their
+	// relative order.
+	Keys []string
+	// Position selects the ranking strategy.
+	Position RankPosition
+	// Anchor is the reference issue key, required by RankBefore / RankAfter and
+	// ignored by RankTop / RankBottom (which resolve their own anchor).
+	Anchor string
+	// Board is an optional board ID or name, only consulted by RankTop /
+	// RankBottom. When empty, the issue's project must have exactly one board.
+	Board string
+}
+
+// RankResult reports what a ranking operation did, including the anchor it
+// resolved, so callers can explain the move to the user.
+type RankResult struct {
+	Issues   []string      `json:"issues"`
+	Position RankPosition  `json:"position"`
+	Anchor   string        `json:"anchor,omitempty"`
+	Board    *models.Board `json:"board,omitempty"`
+	Column   string        `json:"column,omitempty"`
+	// NoOp is true when the issues already occupied the requested edge of the
+	// column and no request was sent.
+	NoOp bool `json:"noop"`
+}
+
+// GetBoards returns the Agile boards visible to the caller, optionally scoped to
+// a project key or ID. Results are paginated with the Agile API's isLast flag.
+func (c *Client) GetBoards(ctx context.Context, projectKeyOrID string) ([]models.Board, error) {
+	var all []models.Board
+	startAt := 0
+
+	for {
+		path := fmt.Sprintf("/board?startAt=%d&maxResults=%d", startAt, pageSize)
+		if projectKeyOrID != "" {
+			path += "&projectKeyOrId=" + url.QueryEscape(projectKeyOrID)
+		}
+
+		data, err := c.doAgile(ctx, http.MethodGet, path, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		var resp models.BoardsResponse
+		if err := json.Unmarshal(data, &resp); err != nil {
+			return nil, fmt.Errorf("parsing boards: %w", err)
+		}
+
+		all = append(all, resp.Values...)
+		if resp.IsLast || len(resp.Values) == 0 {
+			break
+		}
+		startAt += len(resp.Values)
+	}
+
+	return all, nil
+}
+
+// GetBoardConfiguration returns a board's saved filter, column layout and rank
+// field. Needed to work out which column an issue currently sits in.
+func (c *Client) GetBoardConfiguration(ctx context.Context, boardID int) (*models.BoardConfiguration, error) {
+	path := fmt.Sprintf("/board/%d/configuration", boardID)
+	data, err := c.doAgile(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var cfg models.BoardConfiguration
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parsing board configuration: %w", err)
+	}
+	return &cfg, nil
+}
+
+// RankIssues performs the raw rank call (PUT /rest/agile/1.0/issue/rank).
+// Prefer RankIssuesRelative, which resolves anchors and validates the request.
+func (c *Client) RankIssues(ctx context.Context, req *models.RankIssuesRequest) error {
+	_, err := c.doAgile(ctx, http.MethodPut, "/issue/rank", req)
+	return err
+}
+
+// RankIssuesRelative moves issues within the board's rank order. For RankTop and
+// RankBottom it resolves the issue's own column on the board and picks the first
+// (or last) issue of that column as the anchor, so "top" means "top of the
+// column the issue is already in". Shared by the CLI `issue rank` command and
+// the jira_rank_issue MCP tool so both resolve boards and columns identically.
+func (c *Client) RankIssuesRelative(ctx context.Context, req RankRequest) (*RankResult, error) {
+	if len(req.Keys) == 0 {
+		return nil, fmt.Errorf("no issues to rank")
+	}
+	if len(req.Keys) > maxRankIssues {
+		return nil, fmt.Errorf("cannot rank more than %d issues in one call (got %d)", maxRankIssues, len(req.Keys))
+	}
+
+	result := &RankResult{Issues: req.Keys, Position: req.Position}
+	var rankFieldID int
+
+	switch req.Position {
+	case RankBefore, RankAfter:
+		if req.Anchor == "" {
+			return nil, fmt.Errorf("position %q requires an anchor issue", req.Position)
+		}
+		if containsFold(req.Keys, req.Anchor) {
+			return nil, fmt.Errorf("cannot rank %s relative to itself", req.Anchor)
+		}
+		id, err := c.ResolveRankField(ctx)
+		if err != nil {
+			return nil, err
+		}
+		rankFieldID = id
+		result.Anchor = req.Anchor
+
+	case RankTop, RankBottom:
+		id, err := c.resolveColumnAnchor(ctx, req, result)
+		if err != nil {
+			return nil, err
+		}
+		rankFieldID = id
+
+	default:
+		return nil, fmt.Errorf("unknown rank position %q", req.Position)
+	}
+
+	if result.NoOp {
+		return result, nil
+	}
+
+	body := &models.RankIssuesRequest{Issues: req.Keys, RankCustomFieldID: rankFieldID}
+	if req.Position == RankAfter || req.Position == RankBottom {
+		body.RankAfterIssue = result.Anchor
+	} else {
+		body.RankBeforeIssue = result.Anchor
+	}
+	if err := c.RankIssues(ctx, body); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// resolveColumnAnchor fills result.Board, result.Column and result.Anchor for a
+// top/bottom move, and returns the rank custom field ID to use. It sets
+// result.NoOp when the moved issues already sit at the requested edge.
+func (c *Client) resolveColumnAnchor(ctx context.Context, req RankRequest, result *RankResult) (int, error) {
+	// The first key decides the project and the column; ranking a block of
+	// issues that live in different columns has no single meaning.
+	issue, err := c.GetIssue(ctx, req.Keys[0])
+	if err != nil {
+		return 0, err
+	}
+	if issue.Fields.Status == nil {
+		return 0, fmt.Errorf("cannot determine the status of %s", req.Keys[0])
+	}
+	statusID, statusName := issue.Fields.Status.ID, issue.Fields.Status.Name
+
+	projectKey := ""
+	if issue.Fields.Project != nil {
+		projectKey = issue.Fields.Project.Key
+	}
+
+	board, err := c.resolveBoard(ctx, projectKey, req.Board)
+	if err != nil {
+		return 0, err
+	}
+
+	cfg, err := c.GetBoardConfiguration(ctx, board.ID)
+	if err != nil {
+		return 0, err
+	}
+	if cfg.Name != "" {
+		board.Name = cfg.Name
+	}
+	if cfg.Type != "" {
+		board.Type = cfg.Type
+	}
+	result.Board = board
+
+	column := findColumnForStatus(cfg.ColumnConfig.Columns, statusID)
+	if column == nil {
+		return 0, fmt.Errorf("status %q of %s is not mapped to any column of board %q; the issue is not shown on that board",
+			statusName, req.Keys[0], board.Name)
+	}
+	result.Column = column.Name
+
+	rankFieldID := 0
+	if cfg.Ranking != nil {
+		rankFieldID = cfg.Ranking.RankCustomFieldID
+	}
+	if rankFieldID == 0 {
+		// Some boards report an empty "ranking" object; fall back to the
+		// instance-wide LexoRank field.
+		if rankFieldID, err = c.ResolveRankField(ctx); err != nil {
+			return 0, err
+		}
+	}
+
+	if cfg.Filter.ID == "" {
+		return 0, fmt.Errorf("board %q does not expose its saved filter, cannot determine column order", board.Name)
+	}
+
+	order := "ASC"
+	if req.Position == RankBottom {
+		order = "DESC"
+	}
+	jql := fmt.Sprintf("filter = %s AND status IN (%s) ORDER BY cf[%d] %s",
+		cfg.Filter.ID, quoteJoin(columnStatusIDs(column)), rankFieldID, order)
+
+	// Fetching len(Keys)+1 issues guarantees at least one candidate that is not
+	// itself being moved, if such an issue exists at all.
+	search, err := c.SearchIssues(ctx, jql, 0, len(req.Keys)+1)
+	if err != nil {
+		return 0, fmt.Errorf("resolving the %s of column %q: %w", req.Position, column.Name, err)
+	}
+
+	for _, candidate := range search.Issues {
+		if !containsFold(req.Keys, candidate.Key) {
+			result.Anchor = candidate.Key
+			return rankFieldID, nil
+		}
+	}
+
+	// Every issue in the column is part of the move: nothing to rank against.
+	result.NoOp = true
+	return rankFieldID, nil
+}
+
+// resolveBoard picks the board for a top/bottom move. A numeric ref is taken as
+// a board ID; a non-numeric ref is matched by name against the project's boards.
+// With no ref, the project must have exactly one board — otherwise the error
+// lists the candidates so the user can pass --board.
+func (c *Client) resolveBoard(ctx context.Context, projectKey, ref string) (*models.Board, error) {
+	if id, err := strconv.Atoi(strings.TrimSpace(ref)); err == nil && id > 0 {
+		return &models.Board{ID: id}, nil
+	}
+
+	if projectKey == "" {
+		return nil, fmt.Errorf("cannot determine the project of the issue; pass a board ID explicitly")
+	}
+
+	boards, err := c.GetBoards(ctx, projectKey)
+	if err != nil {
+		return nil, err
+	}
+	if len(boards) == 0 {
+		return nil, fmt.Errorf("project %s has no Agile boards", projectKey)
+	}
+
+	if ref != "" {
+		for i, b := range boards {
+			if strings.EqualFold(b.Name, ref) {
+				return &boards[i], nil
+			}
+		}
+		return nil, fmt.Errorf("board %q not found in project %s; available: %s", ref, projectKey, describeBoards(boards))
+	}
+
+	if len(boards) > 1 {
+		return nil, fmt.Errorf("project %s has %d boards, specify one: %s", projectKey, len(boards), describeBoards(boards))
+	}
+	return &boards[0], nil
+}
+
+// findColumnForStatus returns the column whose status set contains statusID.
+func findColumnForStatus(columns []models.BoardColumn, statusID string) *models.BoardColumn {
+	for i, col := range columns {
+		for _, st := range col.Statuses {
+			if st.ID == statusID {
+				return &columns[i]
+			}
+		}
+	}
+	return nil
+}
+
+// columnStatusIDs returns the status IDs mapped to a column.
+func columnStatusIDs(col *models.BoardColumn) []string {
+	out := make([]string, 0, len(col.Statuses))
+	for _, st := range col.Statuses {
+		out = append(out, st.ID)
+	}
+	return out
+}
+
+// describeBoards renders boards as `name (id, type)` for error messages.
+func describeBoards(boards []models.Board) string {
+	out := make([]string, 0, len(boards))
+	for _, b := range boards {
+		out = append(out, fmt.Sprintf("%q (%d, %s)", b.Name, b.ID, b.Type))
+	}
+	return strings.Join(out, ", ")
+}
+
+// quoteJoin renders values as a quoted, comma-separated JQL list.
+func quoteJoin(values []string) string {
+	out := make([]string, 0, len(values))
+	for _, v := range values {
+		out = append(out, `"`+v+`"`)
+	}
+	return strings.Join(out, ", ")
+}
+
+// containsFold reports whether values contains target, ignoring case (Jira issue
+// keys are case-insensitive).
+func containsFold(values []string, target string) bool {
+	for _, v := range values {
+		if strings.EqualFold(v, target) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/client/rank_test.go
+++ b/internal/client/rank_test.go
@@ -1,0 +1,442 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/amplia/jira8/internal/config"
+	"github.com/amplia/jira8/internal/models"
+)
+
+// fakeJira emulates the endpoints RankIssuesRelative touches: issue lookup,
+// Agile boards and their configuration, JQL search and the rank call itself.
+type fakeJira struct {
+	t *testing.T
+	// statuses maps issue key → status ID.
+	statuses map[string]string
+	// project is the project key reported for every issue ("" to omit it).
+	project string
+	// boards is what GET /board returns for the project.
+	boards []models.Board
+	// columns is the board's column configuration.
+	columns []models.BoardColumn
+	// ranking is the board's reported rank field ("nil" → empty object, which
+	// forces the /field fallback).
+	ranking *models.BoardRanking
+	// columnIssues is the column content in ascending rank order.
+	columnIssues []string
+
+	// Captured for assertions.
+	lastJQL   string
+	rankBody  models.RankIssuesRequest
+	rankCalls int
+	fieldGets int
+}
+
+func (f *fakeJira) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	path := r.URL.Path
+	w.Header().Set("Content-Type", "application/json")
+
+	switch {
+	case r.Method == http.MethodPut && strings.HasSuffix(path, "/rest/agile/1.0/issue/rank"):
+		f.rankCalls++
+		if err := json.NewDecoder(r.Body).Decode(&f.rankBody); err != nil {
+			f.t.Errorf("decoding rank body: %v", err)
+		}
+		w.WriteHeader(http.StatusNoContent)
+
+	case strings.HasSuffix(path, "/rest/agile/1.0/board"):
+		if got := r.URL.Query().Get("projectKeyOrId"); got != f.project {
+			f.t.Errorf("board query projectKeyOrId = %q, want %q", got, f.project)
+		}
+		_ = json.NewEncoder(w).Encode(models.BoardsResponse{
+			IsLast: true, Total: len(f.boards), Values: f.boards,
+		})
+
+	case strings.Contains(path, "/rest/agile/1.0/board/") && strings.HasSuffix(path, "/configuration"):
+		_ = json.NewEncoder(w).Encode(models.BoardConfiguration{
+			ID:           f.boards[0].ID,
+			Name:         f.boards[0].Name,
+			Type:         f.boards[0].Type,
+			Filter:       models.BoardFilter{ID: "12809"},
+			ColumnConfig: models.BoardColumnConfig{Columns: f.columns},
+			Ranking:      f.ranking,
+		})
+
+	case strings.HasSuffix(path, "/rest/api/2/search"):
+		f.lastJQL = r.URL.Query().Get("jql")
+		keys := append([]string{}, f.columnIssues...)
+		if strings.Contains(f.lastJQL, "DESC") {
+			for i, j := 0, len(keys)-1; i < j; i, j = i+1, j-1 {
+				keys[i], keys[j] = keys[j], keys[i]
+			}
+		}
+		issues := make([]models.Issue, 0, len(keys))
+		for _, k := range keys {
+			issues = append(issues, models.Issue{Key: k})
+		}
+		_ = json.NewEncoder(w).Encode(models.SearchResult{Total: len(issues), Issues: issues})
+
+	case strings.HasSuffix(path, "/rest/api/2/field"):
+		f.fieldGets++
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{"id": "customfield_10002", "name": "Rank (Obsolete)", "custom": true,
+				"schema": map[string]any{"custom": "com.pyxis.greenhopper.jira:gh-global-rank"}},
+			{"id": "customfield_10200", "name": "Rank", "custom": true,
+				"schema": map[string]any{"custom": SchemaRank}},
+		})
+
+	case strings.Contains(path, "/rest/api/2/issue/"):
+		key := path[strings.LastIndex(path, "/")+1:]
+		status, ok := f.statuses[key]
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		fields := map[string]any{"status": map[string]any{"id": status, "name": "Status " + status}}
+		if f.project != "" {
+			fields["project"] = map[string]any{"key": f.project}
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"key": key, "fields": fields})
+
+	default:
+		f.t.Errorf("unexpected request: %s %s", r.Method, path)
+		http.NotFound(w, r)
+	}
+}
+
+// newFake returns a fake Jira with one kanban board whose "In Progress" column
+// holds PHO-1, PHO-2 and PHO-3 in that rank order.
+func newFake(t *testing.T) (*fakeJira, *Client, func()) {
+	f := &fakeJira{
+		t:        t,
+		project:  "PHO",
+		statuses: map[string]string{"PHO-1": "3", "PHO-2": "3", "PHO-3": "3", "PHO-9": "99"},
+		boards:   []models.Board{{ID: 110, Name: "Phoenix Kanban", Type: "kanban"}},
+		columns: []models.BoardColumn{
+			{Name: "Backlog", Statuses: []models.BoardColumnStatus{{ID: "10006"}}},
+			{Name: "In Progress", Statuses: []models.BoardColumnStatus{{ID: "3"}, {ID: "10003"}}},
+		},
+		ranking:      &models.BoardRanking{RankCustomFieldID: 10200},
+		columnIssues: []string{"PHO-1", "PHO-2", "PHO-3"},
+	}
+	srv := httptest.NewServer(f)
+	return f, New(&config.Config{URL: srv.URL, Token: "x"}), srv.Close
+}
+
+func TestRankTop(t *testing.T) {
+	f, c, done := newFake(t)
+	defer done()
+
+	got, err := c.RankIssuesRelative(context.Background(), RankRequest{
+		Keys: []string{"PHO-3"}, Position: RankTop,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got.Anchor != "PHO-1" {
+		t.Errorf("anchor = %q, want PHO-1 (first issue of the column)", got.Anchor)
+	}
+	if got.Column != "In Progress" {
+		t.Errorf("column = %q, want In Progress", got.Column)
+	}
+	if got.Board == nil || got.Board.Name != "Phoenix Kanban" {
+		t.Errorf("board = %+v, want Phoenix Kanban", got.Board)
+	}
+	if got.NoOp {
+		t.Error("NoOp = true, want false")
+	}
+
+	// The column's statuses must scope the query, ordered by the board's rank field.
+	for _, want := range []string{"filter = 12809", `status IN ("3", "10003")`, "ORDER BY cf[10200] ASC"} {
+		if !strings.Contains(f.lastJQL, want) {
+			t.Errorf("JQL %q does not contain %q", f.lastJQL, want)
+		}
+	}
+	if f.rankBody.RankBeforeIssue != "PHO-1" {
+		t.Errorf("rankBeforeIssue = %q, want PHO-1", f.rankBody.RankBeforeIssue)
+	}
+	if f.rankBody.RankAfterIssue != "" {
+		t.Errorf("rankAfterIssue = %q, want empty", f.rankBody.RankAfterIssue)
+	}
+	if f.rankBody.RankCustomFieldID != 10200 {
+		t.Errorf("rankCustomFieldId = %d, want 10200", f.rankBody.RankCustomFieldID)
+	}
+	if f.fieldGets != 0 {
+		t.Errorf("GET /field calls = %d, want 0 (board reported the rank field)", f.fieldGets)
+	}
+}
+
+// The issue already at the top must anchor on the next issue, which leaves it in
+// place instead of ranking it relative to itself.
+func TestRankTop_AlreadyFirstIsIdempotent(t *testing.T) {
+	f, c, done := newFake(t)
+	defer done()
+
+	got, err := c.RankIssuesRelative(context.Background(), RankRequest{
+		Keys: []string{"PHO-1"}, Position: RankTop,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Anchor != "PHO-2" {
+		t.Errorf("anchor = %q, want PHO-2", got.Anchor)
+	}
+	if f.rankBody.RankBeforeIssue != "PHO-2" {
+		t.Errorf("rankBeforeIssue = %q, want PHO-2", f.rankBody.RankBeforeIssue)
+	}
+}
+
+func TestRankBottom(t *testing.T) {
+	f, c, done := newFake(t)
+	defer done()
+
+	got, err := c.RankIssuesRelative(context.Background(), RankRequest{
+		Keys: []string{"PHO-1"}, Position: RankBottom,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Anchor != "PHO-3" {
+		t.Errorf("anchor = %q, want PHO-3 (last issue of the column)", got.Anchor)
+	}
+	if !strings.Contains(f.lastJQL, "ORDER BY cf[10200] DESC") {
+		t.Errorf("JQL %q must order descending for a bottom move", f.lastJQL)
+	}
+	if f.rankBody.RankAfterIssue != "PHO-3" {
+		t.Errorf("rankAfterIssue = %q, want PHO-3", f.rankBody.RankAfterIssue)
+	}
+	if f.rankBody.RankBeforeIssue != "" {
+		t.Errorf("rankBeforeIssue = %q, want empty", f.rankBody.RankBeforeIssue)
+	}
+}
+
+// Ranking a block keeps the whole set out of the anchor search: the anchor must
+// be the first issue that is not being moved.
+func TestRankTop_BlockSkipsMovedIssues(t *testing.T) {
+	f, c, done := newFake(t)
+	defer done()
+
+	got, err := c.RankIssuesRelative(context.Background(), RankRequest{
+		Keys: []string{"PHO-1", "PHO-2"}, Position: RankTop,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Anchor != "PHO-3" {
+		t.Errorf("anchor = %q, want PHO-3", got.Anchor)
+	}
+	if len(f.rankBody.Issues) != 2 || f.rankBody.Issues[0] != "PHO-1" {
+		t.Errorf("issues = %v, want [PHO-1 PHO-2] in order", f.rankBody.Issues)
+	}
+}
+
+// When every issue in the column is being moved there is no anchor to rank
+// against, so the operation must be reported as a no-op without calling Jira.
+func TestRankTop_NoOpWhenColumnFullyMoved(t *testing.T) {
+	f, c, done := newFake(t)
+	defer done()
+	f.columnIssues = []string{"PHO-1"}
+
+	got, err := c.RankIssuesRelative(context.Background(), RankRequest{
+		Keys: []string{"PHO-1"}, Position: RankTop,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !got.NoOp {
+		t.Error("NoOp = false, want true")
+	}
+	if got.Anchor != "" {
+		t.Errorf("anchor = %q, want empty", got.Anchor)
+	}
+	if f.rankCalls != 0 {
+		t.Errorf("rank calls = %d, want 0", f.rankCalls)
+	}
+}
+
+// Boards that report an empty "ranking" object must fall back to resolving the
+// LexoRank field from /field — and must not pick the obsolete global rank.
+func TestRankTop_RankFieldFallback(t *testing.T) {
+	f, c, done := newFake(t)
+	defer done()
+	f.ranking = nil
+
+	if _, err := c.RankIssuesRelative(context.Background(), RankRequest{
+		Keys: []string{"PHO-3"}, Position: RankTop,
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if f.fieldGets != 1 {
+		t.Errorf("GET /field calls = %d, want 1", f.fieldGets)
+	}
+	if f.rankBody.RankCustomFieldID != 10200 {
+		t.Errorf("rankCustomFieldId = %d, want 10200", f.rankBody.RankCustomFieldID)
+	}
+	if !strings.Contains(f.lastJQL, "cf[10200]") {
+		t.Errorf("JQL %q must order by the resolved rank field", f.lastJQL)
+	}
+}
+
+// An issue whose status is not mapped to any column is not on the board, so
+// "top of its column" is meaningless and must fail loudly.
+func TestRankTop_StatusNotOnBoard(t *testing.T) {
+	f, c, done := newFake(t)
+	defer done()
+
+	_, err := c.RankIssuesRelative(context.Background(), RankRequest{
+		Keys: []string{"PHO-9"}, Position: RankTop,
+	})
+	if err == nil {
+		t.Fatal("expected an error for a status outside the board columns")
+	}
+	if !strings.Contains(err.Error(), "not mapped to any column") {
+		t.Errorf("error = %v, want it to explain the unmapped status", err)
+	}
+	if f.rankCalls != 0 {
+		t.Errorf("rank calls = %d, want 0", f.rankCalls)
+	}
+}
+
+func TestRankTop_AmbiguousBoard(t *testing.T) {
+	f, c, done := newFake(t)
+	defer done()
+	f.boards = append(f.boards, models.Board{ID: 119, Name: "Phoenix Scrum", Type: "scrum"})
+
+	_, err := c.RankIssuesRelative(context.Background(), RankRequest{
+		Keys: []string{"PHO-1"}, Position: RankTop,
+	})
+	if err == nil {
+		t.Fatal("expected an error when the project has several boards")
+	}
+	// The message must name the candidates so the user can pick one.
+	for _, want := range []string{"Phoenix Kanban", "Phoenix Scrum", "110", "119"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %v does not mention %q", err, want)
+		}
+	}
+}
+
+func TestRankTop_BoardByName(t *testing.T) {
+	f, c, done := newFake(t)
+	defer done()
+	f.boards = append(f.boards, models.Board{ID: 119, Name: "Phoenix Scrum", Type: "scrum"})
+
+	got, err := c.RankIssuesRelative(context.Background(), RankRequest{
+		Keys: []string{"PHO-3"}, Position: RankTop, Board: "phoenix kanban",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Board == nil || got.Board.ID != 110 {
+		t.Errorf("board = %+v, want ID 110 matched case-insensitively by name", got.Board)
+	}
+}
+
+func TestRankTop_BoardNotFound(t *testing.T) {
+	_, c, done := newFake(t)
+	defer done()
+
+	_, err := c.RankIssuesRelative(context.Background(), RankRequest{
+		Keys: []string{"PHO-1"}, Position: RankTop, Board: "Nonexistent",
+	})
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("error = %v, want a not-found error listing the boards", err)
+	}
+}
+
+// before/after need no board lookup: the anchor is explicit.
+func TestRankBefore(t *testing.T) {
+	f, c, done := newFake(t)
+	defer done()
+
+	got, err := c.RankIssuesRelative(context.Background(), RankRequest{
+		Keys: []string{"PHO-3"}, Position: RankBefore, Anchor: "PHO-1",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Anchor != "PHO-1" || got.Board != nil || got.Column != "" {
+		t.Errorf("result = %+v, want anchor PHO-1 and no board/column lookup", got)
+	}
+	if f.rankBody.RankBeforeIssue != "PHO-1" {
+		t.Errorf("rankBeforeIssue = %q, want PHO-1", f.rankBody.RankBeforeIssue)
+	}
+	if f.rankBody.RankCustomFieldID != 10200 {
+		t.Errorf("rankCustomFieldId = %d, want 10200", f.rankBody.RankCustomFieldID)
+	}
+	if f.lastJQL != "" {
+		t.Errorf("unexpected search for an explicit anchor: %q", f.lastJQL)
+	}
+}
+
+func TestRankAfter(t *testing.T) {
+	f, c, done := newFake(t)
+	defer done()
+
+	if _, err := c.RankIssuesRelative(context.Background(), RankRequest{
+		Keys: []string{"PHO-1"}, Position: RankAfter, Anchor: "PHO-3",
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if f.rankBody.RankAfterIssue != "PHO-3" {
+		t.Errorf("rankAfterIssue = %q, want PHO-3", f.rankBody.RankAfterIssue)
+	}
+}
+
+func TestRankIssuesRelative_Validation(t *testing.T) {
+	tests := []struct {
+		name string
+		req  RankRequest
+		want string
+	}{
+		{
+			name: "no keys",
+			req:  RankRequest{Position: RankTop},
+			want: "no issues to rank",
+		},
+		{
+			name: "anchor is the moved issue",
+			req:  RankRequest{Keys: []string{"PHO-1"}, Position: RankBefore, Anchor: "pho-1"},
+			want: "relative to itself",
+		},
+		{
+			name: "missing anchor",
+			req:  RankRequest{Keys: []string{"PHO-1"}, Position: RankAfter},
+			want: "requires an anchor",
+		},
+		{
+			name: "unknown position",
+			req:  RankRequest{Keys: []string{"PHO-1"}, Position: RankPosition("sideways")},
+			want: "unknown rank position",
+		},
+		{
+			name: "too many issues",
+			req:  RankRequest{Keys: make([]string, maxRankIssues+1), Position: RankTop},
+			want: "cannot rank more than 50",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f, c, done := newFake(t)
+			defer done()
+
+			_, err := c.RankIssuesRelative(context.Background(), tc.req)
+			if err == nil {
+				t.Fatalf("expected an error containing %q", tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error = %v, want it to contain %q", err, tc.want)
+			}
+			if f.rankCalls != 0 {
+				t.Errorf("rank calls = %d, want 0", f.rankCalls)
+			}
+		})
+	}
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -407,3 +407,82 @@ type FieldSchema struct {
 	Items  string `json:"items,omitempty"`
 	Custom string `json:"custom,omitempty"`
 }
+
+// Board is an Agile (Greenhopper) board as returned by
+// GET /rest/agile/1.0/board. Type is "kanban" or "scrum".
+type Board struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+	Type string `json:"type,omitempty"`
+}
+
+// BoardsResponse is the paginated envelope returned by GET /rest/agile/1.0/board.
+// The Agile API paginates with isLast rather than the startAt/total arithmetic
+// used by /rest/api/2/search.
+type BoardsResponse struct {
+	MaxResults int     `json:"maxResults"`
+	StartAt    int     `json:"startAt"`
+	Total      int     `json:"total"`
+	IsLast     bool    `json:"isLast"`
+	Values     []Board `json:"values"`
+}
+
+// BoardConfiguration is returned by GET /rest/agile/1.0/board/{id}/configuration.
+// It is the only source for two things ranking needs: the board's saved filter
+// (to scope a JQL query to exactly what the board shows) and the column→statuses
+// mapping (to know which statuses make up a kanban column).
+type BoardConfiguration struct {
+	ID           int               `json:"id"`
+	Name         string            `json:"name"`
+	Type         string            `json:"type,omitempty"`
+	Filter       BoardFilter       `json:"filter"`
+	ColumnConfig BoardColumnConfig `json:"columnConfig"`
+	// Ranking carries the instance's rank custom field ID. Some boards return an
+	// empty object here, so callers must fall back to resolving SchemaRank via
+	// GET /rest/api/2/field.
+	Ranking *BoardRanking `json:"ranking,omitempty"`
+}
+
+// BoardFilter references the saved filter backing a board. The ID is a string in
+// the Agile API payload even though it is numeric.
+type BoardFilter struct {
+	ID string `json:"id"`
+}
+
+// BoardColumnConfig holds the ordered columns of a board, left to right.
+type BoardColumnConfig struct {
+	Columns []BoardColumn `json:"columns"`
+}
+
+// BoardColumn is a single board column. A column maps to zero or more statuses;
+// an issue belongs to the column whose Statuses contain the issue's status ID.
+// Columns with no statuses (a disabled kanban Backlog, for instance) hold nothing.
+type BoardColumn struct {
+	Name     string              `json:"name"`
+	Statuses []BoardColumnStatus `json:"statuses"`
+}
+
+// BoardColumnStatus references a status mapped to a column.
+type BoardColumnStatus struct {
+	ID string `json:"id"`
+}
+
+// BoardRanking carries the numeric ID of the LexoRank custom field used by the
+// board (e.g. 10200 for customfield_10200).
+type BoardRanking struct {
+	RankCustomFieldID int `json:"rankCustomFieldId,omitempty"`
+}
+
+// RankIssuesRequest is the PUT body for /rest/agile/1.0/issue/rank. Exactly one
+// of RankBeforeIssue / RankAfterIssue must be set; the moved issues keep their
+// relative order and land immediately before (or after) the anchor. Jira accepts
+// at most 50 issues per call.
+type RankIssuesRequest struct {
+	Issues          []string `json:"issues"`
+	RankBeforeIssue string   `json:"rankBeforeIssue,omitempty"`
+	RankAfterIssue  string   `json:"rankAfterIssue,omitempty"`
+	// RankCustomFieldID is optional per the API docs, but Jira Server instances
+	// can expose more than one rank field (an obsolete global rank alongside the
+	// LexoRank one), so we always send the resolved ID to stay unambiguous.
+	RankCustomFieldID int `json:"rankCustomFieldId,omitempty"`
+}


### PR DESCRIPTION
Closes #56.

Adds ranking — the missing primitive for kanban order. Ranking moves an issue up
or down **within** its column; it never changes the status (that is `issue transition`).

## CLI

```
jira8 issue rank ISSUE-KEY... (--top | --bottom | --before KEY | --after KEY) [--board <id|name>]
```

`--top` / `--bottom` are the headline feature: they resolve which column the issue
currently sits in (from the board's status→column mapping) and move it to that
column's edge, anchoring on the first/last issue of the column that is not itself
being moved. That makes the operation idempotent — ranking an issue that is
already first leaves the board unchanged instead of failing on a self-reference.

Up to 50 keys can be ranked as a block, keeping their relative order.

## MCP

`jira_rank_issue` with parameters matching the flags (`keys`/`key`, `top`,
`bottom`, `before`, `after`, `board`). Ambiguous calls (two positions, or none)
are rejected rather than resolved by guessing, since a wrong guess moves real
issues on someone's board.

## Implementation notes

- The client only reached `/rest/api/2`; `do()` now delegates to `doAt()`, with
  `doAgile()` for `/rest/agile/1.0`. Boards and ranking live there — the legacy
  `/rest/greenhopper/1.0` endpoints are gone in Jira Server 8 (verified 404).
- Column order comes from `filter = <boardFilterId> AND status IN (<columnStatuses>)
  ORDER BY cf[<rankField>] ASC|DESC`, which reproduces the board's true order.
- The rank field is taken from the board's `ranking.rankCustomFieldId`, falling
  back to resolving `com.pyxis.greenhopper.jira:gh-lexo-rank` via `/field`. That
  fallback is needed: at least one board on our instance returns `ranking: {}`.
  The obsolete `gh-global-rank` field is deliberately never used.
- Board/column resolution lives in `RankIssuesRelative` so CLI and MCP behave
  identically, per the parity rule in CLAUDE.md.

## Testing

- 13 unit tests over a fake Agile API: top/bottom anchors, block moves,
  idempotence when already at the edge, no-op when the whole column is moved,
  rank-field fallback, unmapped status, ambiguous/named/missing board,
  before/after, and input validation.
- Verified end-to-end against `jira.amplia.es` (Jira Software Server 8.7.1) with
  a deliberately neutral move: `PHO-173 --top`, which was already first in its
  column. Board resolved by both ID and name, anchor `PHO-4554`, column
  "In Progress", and the column order was byte-identical afterwards. The same
  call through the MCP tool returned the same result.